### PR TITLE
fix: check on empty string in roundAmount

### DIFF
--- a/library/common.php
+++ b/library/common.php
@@ -875,9 +875,9 @@ function getClientIpBuckaroo()
     return "";
 }
 
-function roundAmount($amount) {
-    if(is_scalar($amount)) {
-	    return (float) number_format($amount, 2, '.', '');
+function roundAmount( $amount ) {
+    if ( is_scalar( $amount ) && ! empty( $amount ) ) {
+        return (float) number_format( $amount, 2, '.', '' );
     }
     return 0;
 }


### PR DESCRIPTION
If an empty string is passed to roundAmount() it triggers a critical:
CRITICAL Uncaught TypeError: number_format(): Argument #1 ($num) must be of type float, string given in /mnt/efs/zwijsen/current/public/app/plugins/wc-buckaroo-bpe-gateway/library/common.php:880

In our case an emptt tax amount -> plugins/wc-buckaroo-bpe-gateway/includes/admin/meta-boxes/views/html-order-shipping.php(96): roundAmount()

So I added an extra check.