### PR TITLE
BP-3570-Change-the-default-value-for-authorized-giftcard-brands

### DIFF
--- a/gateway-buckaroo-giftcard.php
+++ b/gateway-buckaroo-giftcard.php
@@ -84,7 +84,7 @@ class WC_Gateway_Buckaroo_Giftcard extends WC_Gateway_Buckaroo
             'title'       => __('List of authorized giftcards', 'wc-buckaroo-bpe-gateway'),
             'type'        => 'text',
             'description' => __('Giftcards must be comma separated', 'wc-buckaroo-bpe-gateway'),
-            'default'     => 'westlandbon,ideal,ippies,babygiftcard,babyparkgiftcard,beautywellness,boekenbon,boekenvoordeel,designshopsgiftcard,fashioncheque,fashionucadeaukaart,fijncadeau,koffiecadeau,kokenzo,kookcadeau,nationaleentertainmentcard,naturesgift,podiumcadeaukaart,shoesaccessories,webshopgiftcard,wijncadeau,wonenzo,yourgift,vvvgiftcard,parfumcadeaukaart');
+            'default'     => 'vvvgiftcard,boekenbon,ideal,bancontact,boekenvoordeel,fashioncheque,yourgift,webshopgiftcard');
     }
 
 }

--- a/library/api/config/configcore.php
+++ b/library/api/config/configcore.php
@@ -40,7 +40,7 @@ abstract class BuckarooConfigCore {
                 $value = 'amex,cartebancaire,cartebleuevisa,dankort,mastercard,postepay,visa,visaelectron,vpay';
                 break;
             case 'BUCKAROO_GIFTCARD_ALLOWED_CARDS':
-                $value = 'westlandbon,ideal,ippies,babygiftcard,babyparkgiftcard,beautywellness,boekenbon,boekenvoordeel,designshopsgiftcard,fashioncheque,fashionucadeaukaart,fijncadeau,koffiecadeau,kokenzo,kookcadeau,nationaleentertainmentcard,naturesgift,podiumcadeaukaart,shoesaccessories,webshopgiftcard,wijncadeau,wonenzo,yourgift,vvvgiftcard,parfumcadeaukaart';
+                $value = 'westlandbon,ideal,ippies,babygiftcard,bancontact,babyparkgiftcard,beautywellness,boekenbon,boekenvoordeel,designshopsgiftcard,fashioncheque,fashionucadeaukaart,fijncadeau,koffiecadeau,kokenzo,kookcadeau,nationaleentertainmentcard,naturesgift,podiumcadeaukaart,shoesaccessories,webshopgiftcard,wijncadeau,wonenzo,yourgift,vvvgiftcard,parfumcadeaukaart';
                 break;
         }
         return $value;


### PR DESCRIPTION
changed default giftcards and added bancontact to allowed cards