### PR TITLE
Fix/creditcard capture

### DIFF
--- a/library/creditcard/Capture.php
+++ b/library/creditcard/Capture.php
@@ -20,12 +20,17 @@ class Buckaroo_Creditcard_Capture_Form
         add_action('add_meta_boxes', array($this, 'add_meta_box_form'), 10, 2);
     }
 
-    public function output($order)
-    {
+    public function output( $order ) {
+        // Convert WP_Post to WC_Order if necessary.
+        if ( $order instanceof WP_Post ) {
+            $order = wc_get_order( $order->ID );
+        }
+
         $order_capture = new Buckaroo_Order_Capture(
             new Buckaroo_Order_Details( $order ),
             new Buckaroo_Http_Request()
         );
+
         include 'capture-form.php';
     }
 

--- a/library/creditcard/Capture.php
+++ b/library/creditcard/Capture.php
@@ -20,7 +20,8 @@ class Buckaroo_Creditcard_Capture_Form
         add_action('add_meta_boxes', array($this, 'add_meta_box_form'), 10, 2);
     }
 
-    public function output( $order ) {
+    public function output( $order )
+    {
         // Convert WP_Post to WC_Order if necessary.
         if ( $order instanceof WP_Post ) {
             $order = wc_get_order( $order->ID );
@@ -42,7 +43,8 @@ class Buckaroo_Creditcard_Capture_Form
      *
      * @return void
      */
-    public function add_meta_box_form( $post_type, $post_or_order ) {
+    public function add_meta_box_form( $post_type, $post_or_order )
+    {
         // Handle both HPOS and traditional post-based orders.
         $is_order_page = in_array( $post_type, array( 'woocommerce_page_wc-orders', 'shop_order' ), true );
 

--- a/library/creditcard/Capture.php
+++ b/library/creditcard/Capture.php
@@ -51,11 +51,17 @@ class Buckaroo_Creditcard_Capture_Form
         }
 
         // Get order object by looking for a post or order.
-        $order = ( $post_or_order instanceof WC_Order )
-            ? $post_or_order
-            : wc_get_order( $post_or_order->ID );
+        $order = (
+            $post_or_order instanceof WC_Order ||
+            $post_or_order instanceof Automattic\WooCommerce\Admin\Overrides\Order
+        )
+        ? $post_or_order
+        : wc_get_order( $post_or_order->ID );
 
-        if ( ! $order instanceof WC_Order ) {
+        if (
+            ! $order instanceof WC_Order &&
+            ! $order instanceof Automattic\WooCommerce\Admin\Overrides\Order
+        ) {
             return;
         }
 


### PR DESCRIPTION
The added code of your last version mixes HPOS and non-HPOS. This is a fix for the creditcard caption. 

IMPORTANT: the same fix should be applied to your other Capture.php files plus I did NOT test this on HPOS enabled sites. I only tested on non-HPOS and there it works.