### PR TITLE
fix: remove checking buckaroo/sdk if it's installed but load plugin a…

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,17 +11,16 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */
 
-use Composer\InstalledVersions;
-
 if (!defined('BK_PLUGIN_FILE')) {
     define('BK_PLUGIN_FILE', __FILE__);
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
+add_action(
+    'plugins_loaded',
+    function () {
+        require_once __DIR__ . '/vendor/autoload.php';
 
-if (!InstalledVersions::isInstalled('buckaroo/sdk')) {
-    error_log('Buckaroo SDK is not installed');
-    return;
-}
-
-(new Buckaroo\Woocommerce\Core\Plugin())->init();
+        (new Buckaroo\Woocommerce\Core\Plugin())->init();
+    },
+    -1
+);


### PR DESCRIPTION
It was not reasonable to use the `InstalledVersions` class just to include it in the list of usable packages with the correct location, so I used a hook to load our plugin earliest, which turns out to solve the problem with dependency conflicts.