### PR TITLE
BP-4301: Fix test transaction messaging and boolean parsing for Buckaroo test mode in HPOC and Legacy

### DIFF
--- a/src/ResponseParser/FormDataParser.php
+++ b/src/ResponseParser/FormDataParser.php
@@ -115,7 +115,7 @@ class FormDataParser extends ResponseParser {
 	}
 
 	public function isTest(): bool {
-		return $this->get( 'brq_test' );
+		return filter_var( $this->get( 'brq_test' ), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
 	}
 
 	public function getRealOrderId() {

--- a/src/ResponseParser/JsonParser.php
+++ b/src/ResponseParser/JsonParser.php
@@ -158,7 +158,7 @@ class JsonParser extends ResponseParser
 
     public function isTest(): bool
     {
-        return $this->get('IsTest');
+        return filter_var( $this->get('IsTest'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
     }
 
     public function getRealOrderId()

--- a/src/Services/Helper.php
+++ b/src/Services/Helper.php
@@ -15,13 +15,17 @@ class Helper {
 		return in_array( $status_code, array( ResponseStatus::BUCKAROO_STATUSCODE_CANCELLED_BY_USER, ResponseStatus::BUCKAROO_STATUSCODE_REJECTED ) );
 	}
 
+    public static function isOrderInstance( $instance ): bool {
+        return $instance instanceof Order || $instance instanceof WC_Order;
+    }
+
 	public static function findOrder( $order_id ) {
 		return self::isWooCommerceVersion3OrGreater() ?
 			wc_get_order( $order_id ) : new WC_Order( $order_id );
 	}
 
 	public static function resolveOrder( $input ) {
-        if ( $input instanceof Order || $input instanceof WC_Order ) {
+        if ( static::isOrderInstance( $input ) ) {
             return $input;
         }
 


### PR DESCRIPTION
This PR fixes the message that indicates whether an order was processed as a test transaction so it now works in both HPOC and Legacy integrations

It also corrects the setting of the `_buckaroo_order_in_test_mode` meta value by updating the Response handler classes `isTest` method to properly parse boolean strings

Closes #345