### PR TITLE
BP-4402: Fix PayPal Express issue

### DIFF
--- a/src/Gateways/PaypalExpress/PaypalExpressOrder.php
+++ b/src/Gateways/PaypalExpress/PaypalExpressOrder.php
@@ -2,6 +2,10 @@
 
 namespace Buckaroo\Woocommerce\Gateways\PaypalExpress;
 
+use WC_Order;
+use WC_Order_Item_Fee;
+use stdClass;
+
 /**
  * PayPal express order class
  * php version 7.2

--- a/src/PaymentProcessors/ReturnProcessor.php
+++ b/src/PaymentProcessors/ReturnProcessor.php
@@ -181,10 +181,6 @@ class ReturnProcessor
 
     protected function getRedirectUrl($paymentGateway, $order, $type = 'success')
     {
-        if (is_admin()) {
-            return wp_get_referer() ?: $order->get_edit_order_url();
-        }
-
         return $type === 'success'
             ? $paymentGateway->get_return_url($order)
             : $paymentGateway->get_failed_url();


### PR DESCRIPTION
* added missing class imports in the PayPal Express controller that were causing issues
* fixed redirect URL handling by removing unnecessary admin condition, ensured `ReturnProcessor` runs consistently, as transactions are not performed in the admin panel