### PR TITLE
Update, Test & Release (4.3.1)

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ Plugin URI: http://www.buckaroo.nl
 Author: Buckaroo
 Author URI: http://www.buckaroo.nl
 Description: Buckaroo payment system plugin for WooCommerce.
-Version: 4.3.0
+Version: 4.3.1
 Text Domain: wc-buckaroo-bpe-gateway
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ Plugin URI: http://www.buckaroo.nl
 Author: Buckaroo
 Author URI: http://www.buckaroo.nl
 Description: Buckaroo payment system plugin for WooCommerce.
-Version: 4.2.3
+Version: 4.3.0
 Text Domain: wc-buckaroo-bpe-gateway
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/languages/wc-buckaroo-bpe-gateway.pot
+++ b/languages/wc-buckaroo-bpe-gateway.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Buckaroo BPE Gateway 4.2.3\n"
+"Project-Id-Version: WC Buckaroo BPE Gateway 4.3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wc-buckaroo-bpe-gateway\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/languages/wc-buckaroo-bpe-gateway.pot
+++ b/languages/wc-buckaroo-bpe-gateway.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Buckaroo BPE Gateway 4.3.0\n"
+"Project-Id-Version: WC Buckaroo BPE Gateway 4.3.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wc-buckaroo-bpe-gateway\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author: Buckaroo
 Tags: WooCommerce, payments, Buckaroo
 Requires at least: 5.3.18
 Tested up to: 6.7.2
-Stable tag: 4.2.3
+Stable tag: 4.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -72,6 +72,11 @@ The “Buckaroo Woocommerce Payments Plugin” has been translated into 3 locale
 [Translate “Buckaroo Woocommerce Payments Plugin” into your language.](https://translate.wordpress.org/projects/wp-plugins/wc-buckaroo-bpe-gateway/)
 
 == Changelog ==
+= 4.3.0 =
+BP-3630: Add payment method: Alipay
+BP-3631: Add payment method: WeChat Pay
+BP-4428: PayPal Express - Plugin does not process response Address
+BP-4372: Push cannot be processed if it contains special characters in customer's IBAN
 = 4.2.3 =
 BP-4362 Fix: Apple pay incorrect amount in WooCommerce in combination with discount rules
 = 4.2.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ The “Buckaroo Woocommerce Payments Plugin” has been translated into 3 locale
 == Changelog ==
 = 4.3.1 =
 BP-4476: Add support for Billink V2
+BP-4479: Keep track for transactionKey for SEPA on-hold orders
 New PHP SDK Version that will solve “guzzle not found” error
 = 4.3.0 =
 BP-3630: Add payment method: Alipay

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author: Buckaroo
 Tags: WooCommerce, payments, Buckaroo
 Requires at least: 5.3.18
 Tested up to: 6.7.2
-Stable tag: 4.3.0
+Stable tag: 4.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -72,6 +72,9 @@ The “Buckaroo Woocommerce Payments Plugin” has been translated into 3 locale
 [Translate “Buckaroo Woocommerce Payments Plugin” into your language.](https://translate.wordpress.org/projects/wp-plugins/wc-buckaroo-bpe-gateway/)
 
 == Changelog ==
+= 4.3.1 =
+BP-4476: Add support for Billink V2
+New PHP SDK Version that will solve “guzzle not found” error
 = 4.3.0 =
 BP-3630: Add payment method: Alipay
 BP-3631: Add payment method: WeChat Pay

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -16,7 +16,7 @@ class Plugin
      *
      * @var string
      */
-    public const VERSION = '4.2.3';
+    public const VERSION = '4.3.0';
 
     /**
      * Instance of PaymentGatewayRegistry.

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -16,7 +16,7 @@ class Plugin
      *
      * @var string
      */
-    public const VERSION = '4.3.0';
+    public const VERSION = '4.3.1';
 
     /**
      * Instance of PaymentGatewayRegistry.

--- a/src/Gateways/Billink/BillinkProcessor.php
+++ b/src/Gateways/Billink/BillinkProcessor.php
@@ -93,7 +93,7 @@ class BillinkProcessor extends AbstractPaymentProcessor
                     'firstName' => $first_name,
                     'lastName' => $this->getAddress('billing', 'last_name'),
                     'birthDate' => $this->getBirthDate(),
-                    'salutation' => $this->request->input('buckaroo-billink-gender'),
+                    'title' => $this->request->input('buckaroo-billink-gender'),
                 ],
                 'address' => [
                     'street' => $streetParts->get_street(),

--- a/src/Gateways/Paypal/PaypalProcessor.php
+++ b/src/Gateways/Paypal/PaypalProcessor.php
@@ -22,7 +22,13 @@ class PaypalProcessor extends AbstractPaymentProcessor
     protected function getMethodBody(): array
     {
         if ($this->isExpress()) {
-            return ['payPalOrderId' => $this->getExpressId()];
+            return [
+                'payPalOrderId' => $this->getExpressId(),
+                'additionalParameters' => [
+                    'is_paypal_express' => true,
+                    'real_order_id' => $this->get_order()->get_id(),
+                ],
+            ];
         }
 
         if ($this->isSellerProtection()) {

--- a/src/PaymentProcessors/PushProcessor.php
+++ b/src/PaymentProcessors/PushProcessor.php
@@ -11,10 +11,18 @@ use Buckaroo\Woocommerce\Services\BuckarooClient;
 use Buckaroo\Woocommerce\Services\Helper;
 use Buckaroo\Woocommerce\Services\Logger;
 use BuckarooDeps\Buckaroo\Resources\Constants\ResponseStatus;
+use WC_Data_Exception;
 use WC_Order;
 
 class PushProcessor
 {
+    /**
+     * @param $order_id
+     * @param WC_Order $order
+     * @param ResponseParser $responseParser
+     * @return array|void
+     * @throws WC_Data_Exception
+     */
     protected function onSuccess($order_id, $order, ResponseParser $responseParser)
     {
         global $woocommerce, $wpdb;
@@ -122,6 +130,7 @@ class PushProcessor
                     break;
                 default:
                     Logger::log('Update status 1. Order status: on-hold');
+                    $order->set_transaction_id($responseParser->getTransactionKey());
                     $order->update_status('on-hold', __($responseParser->getSubCodeMessage(), 'wc-buckaroo-bpe-gateway'));
                     // Reduce stock levels
                     break;


### PR DESCRIPTION
- BP-4476: Add support for Billink V2
- BP-4479: Keep track for transactionKey for SEPA on-hold orders
- New PHP SDK Version that will solve “guzzle not found” error