### PR TITLE
BTI-708: fix ideal|wero label reverting on every page load

### DIFF
--- a/assets/js/package-lock.json
+++ b/assets/js/package-lock.json
@@ -72,7 +72,6 @@
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -1708,11 +1707,12 @@
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -1816,7 +1816,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -1901,6 +1900,7 @@
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -1912,17 +1912,19 @@
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/express": {
             "version": "4.17.21",
@@ -2045,7 +2047,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
             "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -2126,6 +2127,7 @@
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.13.2",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -2136,21 +2138,24 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
@@ -2158,6 +2163,7 @@
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.13.2",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2169,7 +2175,8 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
@@ -2177,6 +2184,7 @@
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2190,6 +2198,7 @@
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -2200,6 +2209,7 @@
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -2209,7 +2219,8 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
@@ -2217,6 +2228,7 @@
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2234,6 +2246,7 @@
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -2248,6 +2261,7 @@
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2261,6 +2275,7 @@
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2276,6 +2291,7 @@
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
@@ -2610,14 +2626,16 @@
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/accepts": {
             "version": "1.3.8",
@@ -2644,16 +2662,31 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.14.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
             }
         },
         "node_modules/ajv": {
@@ -2662,7 +2695,6 @@
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2832,6 +2864,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.9.19",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+            "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.js"
+            }
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -2942,9 +2984,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "funding": [
                 {
@@ -2961,12 +3003,12 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001688",
-                "electron-to-chromium": "^1.5.73",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.1"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2980,7 +3022,8 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/bundle-name": {
             "version": "4.1.0",
@@ -3050,9 +3093,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001714",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz",
-            "integrity": "sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==",
+            "version": "1.0.30001769",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+            "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
             "dev": true,
             "funding": [
                 {
@@ -3132,6 +3175,7 @@
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -3213,7 +3257,8 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/common-path-prefix": {
             "version": "3.0.0",
@@ -3635,9 +3680,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.137",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.137.tgz",
-            "integrity": "sha512-/QSJaU2JyIuTbbABAo/crOs+SuAZLS+fVVS10PVrIT9hrRkmZl8Hb0xPSkKRUUWHQtYzXHpQUW3Dy5hwMzGZkA==",
+            "version": "1.5.286",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+            "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
             "dev": true,
             "license": "ISC"
         },
@@ -3668,14 +3713,15 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-            "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+            "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.0"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -3721,11 +3767,12 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-            "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -3763,6 +3810,7 @@
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -3777,6 +3825,7 @@
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -3790,6 +3839,7 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3800,6 +3850,7 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3837,6 +3888,7 @@
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -4242,7 +4294,8 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true,
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/globals": {
             "version": "11.12.0",
@@ -4296,6 +4349,7 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4824,6 +4878,7 @@
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -4857,7 +4912,8 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -4908,13 +4964,18 @@
             }
         },
         "node_modules/loader-runner": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+            "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/locate-path": {
@@ -5032,7 +5093,8 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -5188,7 +5250,8 @@
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/no-case": {
             "version": "3.0.4",
@@ -5211,9 +5274,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.27",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
             "dev": true,
             "license": "MIT"
         },
@@ -5519,7 +5582,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -5620,7 +5682,6 @@
             "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -5695,6 +5756,7 @@
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -5743,7 +5805,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -5774,7 +5835,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -5869,8 +5929,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -6113,9 +6172,9 @@
             }
         },
         "node_modules/schema-utils": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-            "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6238,6 +6297,7 @@
             "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -6517,6 +6577,7 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6537,6 +6598,7 @@
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -6727,6 +6789,7 @@
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -6760,24 +6823,30 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/terser": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-            "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+            "version": "5.46.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+            "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.8.2",
+                "acorn": "^8.15.0",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
             },
@@ -6789,11 +6858,12 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.14",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-            "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+            "version": "5.3.16",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
+            "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
@@ -6893,8 +6963,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/type-is": {
             "version": "1.6.18",
@@ -6972,9 +7041,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
                 {
@@ -7076,11 +7145,12 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-            "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -7100,36 +7170,38 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.99.5",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.5.tgz",
-            "integrity": "sha512-q+vHBa6H9qwBLUlHL4Y7L0L1/LlyBKZtS9FHNCQmtayxjI5RKC9yD8gpvLeqGv5lCQp1Re04yi0MF40pf30Pvg==",
+            "version": "5.105.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+            "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
-                "es-module-lexer": "^1.2.1",
+                "enhanced-resolve": "^5.19.0",
+                "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
                 "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
+                "loader-runner": "^4.3.1",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.0",
-                "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.11",
-                "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
+                "terser-webpack-plugin": "^5.3.16",
+                "watchpack": "^2.5.1",
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -7153,7 +7225,6 @@
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",
@@ -7323,9 +7394,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+            "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/assets/js/package-lock.json
+++ b/assets/js/package-lock.json
@@ -72,7 +72,6 @@
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -1713,6 +1712,7 @@
             "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -1816,7 +1816,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -1901,6 +1900,7 @@
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -1912,6 +1912,7 @@
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -1922,7 +1923,8 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
             "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/express": {
             "version": "4.17.21",
@@ -2045,7 +2047,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
             "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -2126,6 +2127,7 @@
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.13.2",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -2136,21 +2138,24 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
@@ -2158,6 +2163,7 @@
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.13.2",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2169,7 +2175,8 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
@@ -2177,6 +2184,7 @@
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2190,6 +2198,7 @@
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -2200,6 +2209,7 @@
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -2209,7 +2219,8 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
@@ -2217,6 +2228,7 @@
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2234,6 +2246,7 @@
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -2248,6 +2261,7 @@
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2261,6 +2275,7 @@
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2276,6 +2291,7 @@
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
@@ -2610,14 +2626,16 @@
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/accepts": {
             "version": "1.3.8",
@@ -2649,6 +2667,7 @@
             "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2662,7 +2681,6 @@
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2919,9 +2937,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2961,7 +2979,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -2980,7 +2997,8 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/bundle-name": {
             "version": "4.1.0",
@@ -3132,6 +3150,7 @@
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -3213,7 +3232,8 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/common-path-prefix": {
             "version": "3.0.0",
@@ -3673,6 +3693,7 @@
             "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -3725,7 +3746,8 @@
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
             "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -3763,6 +3785,7 @@
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -3777,6 +3800,7 @@
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -3790,6 +3814,7 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3800,6 +3825,7 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3837,6 +3863,7 @@
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -4242,7 +4269,8 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true,
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/globals": {
             "version": "11.12.0",
@@ -4296,6 +4324,7 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4824,6 +4853,7 @@
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -4857,7 +4887,8 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -4913,6 +4944,7 @@
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             }
@@ -5032,7 +5064,8 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -5102,13 +5135,13 @@
             "license": "ISC"
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5188,7 +5221,8 @@
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/no-case": {
             "version": "3.0.4",
@@ -5519,7 +5553,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -5620,7 +5653,6 @@
             "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -5695,6 +5727,7 @@
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -5743,7 +5776,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -5774,7 +5806,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -5869,8 +5900,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -6238,6 +6268,7 @@
             "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -6517,6 +6548,7 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6537,6 +6569,7 @@
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -6727,6 +6760,7 @@
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -6765,6 +6799,7 @@
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6775,6 +6810,7 @@
             "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -6794,6 +6830,7 @@
             "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
@@ -6893,8 +6930,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/type-is": {
             "version": "1.6.18",
@@ -7081,6 +7117,7 @@
             "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -7153,7 +7190,6 @@
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",

--- a/library/buckaroo_images/svg/bancontact.svg
+++ b/library/buckaroo_images/svg/bancontact.svg
@@ -1,216 +1,42 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 232.6 174.45" style="enable-background:new 0 0 232.6 174.45;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#FFFFFF;}
-	.st1{clip-path:url(#SVGID_2_);fill-rule:evenodd;clip-rule:evenodd;fill:#FFDE7F;}
-	.st2{clip-path:url(#SVGID_2_);fill-rule:evenodd;clip-rule:evenodd;fill:#86BBE7;}
-	.st3{fill-rule:evenodd;clip-rule:evenodd;fill:#014787;}
-	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
-	.st5{fill-rule:evenodd;clip-rule:evenodd;fill:#EDEDED;}
-	.st6{clip-path:url(#SVGID_4_);}
-	.st7{clip-path:url(#SVGID_6_);}
-	.st8{fill-rule:evenodd;clip-rule:evenodd;fill:#1C3377;}
-	.st9{fill-rule:evenodd;clip-rule:evenodd;fill:#328F3F;}
-	.st10{fill-rule:evenodd;clip-rule:evenodd;fill:none;}
-	.st11{fill-rule:evenodd;clip-rule:evenodd;fill:#0018A8;}
-	.st12{fill-rule:evenodd;clip-rule:evenodd;fill:#00927B;}
-	.st13{fill-rule:evenodd;clip-rule:evenodd;fill:#D13139;}
-	.st14{clip-path:url(#SVGID_10_);fill-rule:evenodd;clip-rule:evenodd;fill:#FFDE7F;}
-	.st15{clip-path:url(#SVGID_10_);fill-rule:evenodd;clip-rule:evenodd;fill:#86BBE7;}
-	.st16{fill-rule:evenodd;clip-rule:evenodd;fill:#3A3A42;}
-	.st17{fill-rule:evenodd;clip-rule:evenodd;fill:#562873;}
-	.st18{fill-rule:evenodd;clip-rule:evenodd;}
-	.st19{fill-rule:evenodd;clip-rule:evenodd;fill:#A81616;}
-	.st20{fill-rule:evenodd;clip-rule:evenodd;fill:#0FDCB5;}
-	.st21{fill-rule:evenodd;clip-rule:evenodd;fill:#FF4785;}
-	.st22{fill-rule:evenodd;clip-rule:evenodd;fill:#2D32AA;}
-	.st23{fill-rule:evenodd;clip-rule:evenodd;fill:#3A97B8;}
-	.st24{fill:none;stroke:#000000;stroke-width:0.5669;stroke-miterlimit:22.9256;}
-	.st25{fill-rule:evenodd;clip-rule:evenodd;fill:#003853;}
-	.st26{fill-rule:evenodd;clip-rule:evenodd;fill:#FEB3C7;}
-	.st27{fill-rule:evenodd;clip-rule:evenodd;fill:#FF6500;}
-	.st28{clip-path:url(#SVGID_12_);fill-rule:evenodd;clip-rule:evenodd;fill:#FFFEFE;}
-	.st29{clip-path:url(#SVGID_12_);fill-rule:evenodd;clip-rule:evenodd;fill:#FF6200;}
-	.st30{fill-rule:evenodd;clip-rule:evenodd;fill:#CCD905;}
-	.st31{fill-rule:evenodd;clip-rule:evenodd;fill:#00ADEF;}
-	.st32{fill-rule:evenodd;clip-rule:evenodd;fill:#009CDE;}
-	.st33{fill-rule:evenodd;clip-rule:evenodd;fill:#377F7B;}
-	.st34{fill-rule:evenodd;clip-rule:evenodd;fill:#1A1A1A;}
-	.st35{fill:none;stroke:#FFFFFF;stroke-width:0.5669;stroke-miterlimit:22.9256;}
-	.st36{fill-rule:evenodd;clip-rule:evenodd;fill:#009287;}
-	.st37{fill-rule:evenodd;clip-rule:evenodd;fill:#99E1DE;}
-	.st38{fill-rule:evenodd;clip-rule:evenodd;fill:#00A1E9;}
-	.st39{fill-rule:evenodd;clip-rule:evenodd;fill:#016FD0;}
-	.st40{fill-rule:evenodd;clip-rule:evenodd;fill:#FEFEFF;}
-	.st41{fill-rule:evenodd;clip-rule:evenodd;fill:#8ABDE9;}
-	.st42{fill-rule:evenodd;clip-rule:evenodd;fill:#EF533D;}
-	.st43{clip-path:url(#SVGID_14_);fill:url(#SVGID_15_);}
-	.st44{clip-path:url(#SVGID_17_);fill:url(#SVGID_18_);}
-	.st45{fill-rule:evenodd;clip-rule:evenodd;fill:#1D3663;}
-	.st46{fill-rule:evenodd;clip-rule:evenodd;fill:#FEFEFE;}
-	.st47{fill-rule:evenodd;clip-rule:evenodd;fill:#C30044;}
-	.st48{fill-rule:evenodd;clip-rule:evenodd;fill:#FFDD00;}
-	.st49{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#2F9B46;}
-	.st50{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#60B54D;}
-	.st51{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#89CC53;}
-	.st52{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#3CB8AD;}
-	.st53{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#3394D7;}
-	.st54{clip-path:url(#SVGID_20_);fill:none;stroke:#3394D7;stroke-width:0.216;stroke-miterlimit:22.9256;}
-	.st55{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#2772BC;}
-	.st56{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#1B5B83;}
-	.st57{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#993233;}
-	.st58{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#E13030;}
-	.st59{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#F28824;}
-	.st60{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#F5C836;}
-	.st61{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#238647;}
-	.st62{clip-path:url(#SVGID_20_);fill-rule:evenodd;clip-rule:evenodd;fill:#EDEDED;}
-	.st63{clip-path:url(#SVGID_22_);fill:url(#SVGID_23_);}
-	.st64{fill-rule:evenodd;clip-rule:evenodd;fill:#184285;}
-	.st65{fill-rule:evenodd;clip-rule:evenodd;fill:#B2DBF4;}
-	.st66{fill-rule:evenodd;clip-rule:evenodd;fill:#68BCEB;}
-	.st67{fill-rule:evenodd;clip-rule:evenodd;fill:#FDFEFE;}
-	.st68{fill-rule:evenodd;clip-rule:evenodd;fill:#1E4A8F;}
-	.st69{filter:url(#Adobe_OpacityMaskFilter);}
-	.st70{clip-path:url(#SVGID_25_);fill:url(#SVGID_27_);}
-	.st71{clip-path:url(#SVGID_25_);mask:url(#SVGID_26_);fill:url(#SVGID_28_);}
-	.st72{fill-rule:evenodd;clip-rule:evenodd;fill:#748DB6;}
-	.st73{fill-rule:evenodd;clip-rule:evenodd;fill:#1A458A;}
-	.st74{fill-rule:evenodd;clip-rule:evenodd;fill:#8097BC;}
-	.st75{filter:url(#Adobe_OpacityMaskFilter_1_);}
-	.st76{clip-path:url(#SVGID_30_);fill:url(#SVGID_32_);}
-	.st77{clip-path:url(#SVGID_30_);mask:url(#SVGID_31_);fill:url(#SVGID_33_);}
-	.st78{clip-path:url(#SVGID_35_);fill-rule:evenodd;clip-rule:evenodd;fill:#2FACDD;}
-	.st79{clip-path:url(#SVGID_35_);fill-rule:evenodd;clip-rule:evenodd;fill:#F49332;}
-	.st80{clip-path:url(#SVGID_35_);fill-rule:evenodd;clip-rule:evenodd;fill:#F7A859;}
-	.st81{clip-path:url(#SVGID_35_);fill-rule:evenodd;clip-rule:evenodd;fill:#5EC7DC;}
-	.st82{clip-path:url(#SVGID_35_);fill-rule:evenodd;clip-rule:evenodd;fill:#32BAE2;}
-	.st83{fill-rule:evenodd;clip-rule:evenodd;fill:#E61E28;}
-	.st84{fill-rule:evenodd;clip-rule:evenodd;fill:#C8036F;}
-	.st85{clip-path:url(#SVGID_37_);fill:url(#SVGID_38_);}
-	.st86{fill-rule:evenodd;clip-rule:evenodd;fill:#000267;}
-	.st87{fill-rule:evenodd;clip-rule:evenodd;fill:#EC2528;}
-	.st88{fill-rule:evenodd;clip-rule:evenodd;fill:#005FA1;}
-	.st89{clip-path:url(#SVGID_40_);fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
-	.st90{fill-rule:evenodd;clip-rule:evenodd;fill:#CB0065;}
-	.st91{fill-rule:evenodd;clip-rule:evenodd;fill:#CB0064;}
-	.st92{fill-rule:evenodd;clip-rule:evenodd;fill:#112F77;}
-	.st93{fill-rule:evenodd;clip-rule:evenodd;fill:#32ECC5;}
-	.st94{fill-rule:evenodd;clip-rule:evenodd;fill:#F46717;}
-	.st95{fill-rule:evenodd;clip-rule:evenodd;fill:#001254;}
-	.st96{fill-rule:evenodd;clip-rule:evenodd;fill:#E5E5E5;}
-	.st97{fill-rule:evenodd;clip-rule:evenodd;fill:#EA001B;}
-	.st98{fill-rule:evenodd;clip-rule:evenodd;fill:#00A0E2;}
-	.st99{fill-rule:evenodd;clip-rule:evenodd;fill:#7375CF;}
-	.st100{fill-rule:evenodd;clip-rule:evenodd;fill:#00A1E5;}
-	.st101{fill-rule:evenodd;clip-rule:evenodd;fill:#00A2E4;}
-	.st102{fill-rule:evenodd;clip-rule:evenodd;fill:#FF0015;}
-	.st103{fill-rule:evenodd;clip-rule:evenodd;fill:#FF9F00;}
-	.st104{fill-rule:evenodd;clip-rule:evenodd;fill:#FE5E00;}
-	.st105{fill-rule:evenodd;clip-rule:evenodd;fill:#2AAACD;}
-	.st106{fill-rule:evenodd;clip-rule:evenodd;fill:#D30D47;}
-	.st107{fill-rule:evenodd;clip-rule:evenodd;fill:#555390;}
-	.st108{fill-rule:evenodd;clip-rule:evenodd;fill:#F9B92E;}
-	.st109{fill-rule:evenodd;clip-rule:evenodd;fill:#009FE3;}
-	.st110{fill-rule:evenodd;clip-rule:evenodd;fill:#DA0812;}
-	.st111{clip-path:url(#SVGID_42_);}
-	.st112{clip-path:url(#SVGID_46_);}
-	.st113{clip-path:url(#SVGID_48_);}
-	.st114{clip-path:url(#SVGID_52_);}
-	.st115{clip-path:url(#SVGID_56_);fill-rule:evenodd;clip-rule:evenodd;fill:#FF6600;}
-	.st116{fill-rule:evenodd;clip-rule:evenodd;fill:#020399;}
-	.st117{fill-rule:evenodd;clip-rule:evenodd;fill:#D90801;}
-	.st118{clip-path:url(#SVGID_58_);}
-	.st119{clip-path:url(#SVGID_60_);}
-	.st120{clip-path:url(#SVGID_64_);}
-	.st121{clip-path:url(#SVGID_66_);}
-	.st122{clip-path:url(#SVGID_70_);}
-	.st123{fill-rule:evenodd;clip-rule:evenodd;fill:#002F3F;}
-	.st124{fill-rule:evenodd;clip-rule:evenodd;fill:#0DE06F;}
-	.st125{fill-rule:evenodd;clip-rule:evenodd;fill:#2B2F76;}
-	.st126{clip-path:url(#SVGID_74_);}
-	.st127{clip-path:url(#SVGID_78_);}
-	.st128{clip-path:url(#SVGID_82_);fill-rule:evenodd;clip-rule:evenodd;fill:#65377F;}
-	.st129{clip-path:url(#SVGID_82_);fill-rule:evenodd;clip-rule:evenodd;fill:#742693;}
-	.st130{clip-path:url(#SVGID_82_);fill-rule:evenodd;clip-rule:evenodd;fill:#A32795;}
-	.st131{clip-path:url(#SVGID_82_);fill-rule:evenodd;clip-rule:evenodd;fill:#723583;}
-	.st132{clip-path:url(#SVGID_82_);fill-rule:evenodd;clip-rule:evenodd;fill:#7F2C7E;}
-	.st133{clip-path:url(#SVGID_84_);}
-	.st134{clip-path:url(#SVGID_86_);}
-	.st135{fill:#FFFEFF;}
-	.st136{fill:#FFBF00;}
-	.st137{fill:#0F298F;}
-	.st138{fill-rule:evenodd;clip-rule:evenodd;fill:#00AFEF;}
-	.st139{fill:#FEFEFE;}
-	.st140{fill:#FEFEFE;stroke:#0F0202;stroke-width:3;stroke-miterlimit:10;}
-	.st141{fill:#00AFEF;}
-</style>
-<path class="st0" d="M211.55,173.28H20.21c-10.32,0-18.69-8.37-18.69-18.69V20.69C1.52,10.37,9.89,2,20.21,2h191.34
-	c10.32,0,18.69,8.37,18.69,18.69v133.9C230.24,164.91,221.87,173.28,211.55,173.28z"/>
-<g>
-	<defs>
-		<path id="SVGID_13_" d="M148.16,69.95l54.99-0.01l-0.01-35.03c-5.36-0.47-12.58-0.07-18.06-0.07c-11.17,0-23.58-1.04-33.79,2.83
-			c-14.24,5.41-27.96,19.66-35.57,32.28L148.16,69.95z"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_13_"  style="overflow:visible;"/>
-	</clipPath>
-	<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="115.7196" y1="51.8778" x2="203.1535" y2="51.8778">
-		<stop  offset="0" style="stop-color:#FDB000"/>
-		<stop  offset="1" style="stop-color:#FED500"/>
-	</linearGradient>
-	<rect x="115.72" y="33.8" style="clip-path:url(#SVGID_2_);fill:url(#SVGID_4_);" width="87.43" height="36.15"/>
+<svg width="96" height="72" viewBox="0 0 96 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_95_259)">
+<path d="M5 0.5H91C93.4853 0.5 95.5 2.51472 95.5 5V67C95.5 69.4853 93.4853 71.5 91 71.5H5C2.51472 71.5 0.5 69.4853 0.5 67V5C0.5 2.51472 2.51472 0.5 5 0.5Z" fill="white" stroke="#F1F1F1"/>
+<mask id="mask0_95_259" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="48" y="11" width="37" height="16">
+<path d="M70.4142 11.9999C59.4302 11.9999 53.9383 19.3223 48.4463 26.6454H84.8928V11.9999H70.4142Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_95_259)">
+<path d="M84.8928 11.9999H48.4463V26.6454H84.8928V11.9999Z" fill="url(#paint0_linear_95_259)"/>
 </g>
-<g>
-	<defs>
-		<path id="SVGID_16_" d="M28.25,105.17c13.54,0,30.64,1.42,44.16-0.92c7.15-1.24,15.49-5.02,21.12-9.57
-			c3.12-2.52,5.66-4.71,8.11-7.43l7.21-8.32c2.09-2.64,5.12-6.1,6.77-9.07c-29.15,0.03-58.29,0.05-87.44,0.06L28.25,105.17z"/>
-	</defs>
-	<clipPath id="SVGID_6_">
-		<use xlink:href="#SVGID_16_"  style="overflow:visible;"/>
-	</clipPath>
-	<linearGradient id="SVGID_8_" gradientUnits="userSpaceOnUse" x1="28.1858" y1="88.2253" x2="115.6217" y2="88.2253">
-		<stop  offset="0" style="stop-color:#0159B6"/>
-		<stop  offset="0.44" style="stop-color:#246BBD"/>
-		<stop  offset="1" style="stop-color:#16407A"/>
-	</linearGradient>
-	<rect x="28.19" y="69.86" style="clip-path:url(#SVGID_6_);fill:url(#SVGID_8_);" width="87.44" height="36.74"/>
+<mask id="mask1_95_259" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="12" y="26" width="37" height="16">
+<path d="M12 26.6454V41.2902H26.4786C37.4625 41.2902 42.9545 33.9672 48.4459 26.6454H12Z" fill="white"/>
+</mask>
+<g mask="url(#mask1_95_259)">
+<path d="M48.4459 26.6454H12V41.2902H48.4459V26.6454Z" fill="url(#paint1_linear_95_259)"/>
 </g>
-<path class="st45" d="M42.82,129.33c1.39-1.49,2.56-2.32,2.53-5.22c-0.02-2.6-1.26-4.22-2.85-5.15c-3.58-2.09-9.88-1.3-14.34-1.37
-	l0.21,25.3c5.06-0.06,11.59,0.73,15.32-1.83c1.64-1.12,2.83-3.35,2.57-6.37C46,131.49,44.42,130.79,42.82,129.33 M33.25,122.1
-	c3.05-0.18,6.97-0.37,6.89,3.14c-0.08,3.46-3.59,2.92-6.83,2.82L33.25,122.1z M33.24,132.1c3.23-0.03,8.01-0.81,7.88,3.36
-	c-0.11,3.48-4.49,3.06-7.82,2.92L33.24,132.1z"/>
-<path class="st45" d="M102.96,134.72c0.76,11.87,18.79,11.88,18.02-1.87c-0.32-5.69-3.97-9.4-10.14-8.8
-	C105.45,124.56,102.58,128.79,102.96,134.72 M110.46,128.57c5.46-3.09,7.4,8.43,2.98,10.28
-	C107.81,141.21,106.2,130.98,110.46,128.57z"/>
-<path class="st45" d="M123.81,125.65l0.03,17.17l4.91,0.03l0.09-14.23c7.66-1.55,6.69,1.13,6.41,14.32l5.11-0.07
-	c-0.07-4.87,1.1-13.51-1.8-16.56C135.41,123,128.02,123.57,123.81,125.65"/>
-<path class="st45" d="M72.39,128.83c8.76-4.57,5.93,8.31,6.52,14.03l4.81-0.03c0.58-4.03,0.72-14-1.62-16.5
-	c-3.37-3.6-10.33-2.44-14.79-0.76l0.15,17.31l4.84,0.03L72.39,128.83z"/>
-<path class="st45" d="M158.67,128.93c3.96-0.94,8.27-2.14,8.44,3.06c-3.29,0.28-5.63-0.71-8.34,1.41
-	c-3.76,2.95-4.43,13.29,13.18,8.54c1.07-12.8,0.67-20.7-14.19-16.96L158.67,128.93z M166.9,139.22c-3.68,1.49-6.98-1.09-4.57-3.38
-	c0.79-0.75,3.39-1.07,4.3-0.46C167.43,135.91,167.23,138.23,166.9,139.22z"/>
-<path class="st45" d="M50.6,128.97c4.93-1.39,8.27-1.76,8.4,3.18c-10.69-1.14-11.86,5.11-9.65,8.38c2.8,4.14,9.92,2.78,14.45,1.31
-	c1.23-15.69-0.36-19.43-14.14-16.92L50.6,128.97z M58.57,139.37c-6.36,1.87-7.57-5.43,0.14-4.01l0.21,3.09
-	C58.76,139.24,58.88,138.85,58.57,139.37z"/>
-<path class="st45" d="M190.97,127.52c1.7,2.09,2.08,0.05,2.46,1.52c-0.01,10-1.54,14.85,9.75,14.06l-0.35-4.13
-	c-4.6,0.57-5-0.94-4.24-10.51l3.92-0.06l0.03-3.96l-4.01-0.14l0.04-4.16l-5.09,0.27l-0.03,3.7l-0.89,0.2
-	c-0.12,0.03-0.5,0.13-0.61,0.18C190.96,124.92,190.97,123.86,190.97,127.52"/>
-<path class="st45" d="M141.73,127.96c0.25,0.07,2.75,0.07,2.78,0.1c0.03,0.03,0.06,0.06,0.09,0.09c0.06,0.06,0.15,0.12,0.15,0.2
-	l0.09,2.26c0.21,5.13-2.13,14.36,9.88,12.36l-0.35-4.02c-4.8,0.58-4.81-1.1-4.26-10.49l3.94,0l0.03-4.06l-4.02,0.04l0-4.21
-	l-5.04,0.23c-0.03,3.48-0.01,3.74-0.24,3.71c-0.65-0.06-2.32-0.01-3.06,0.02C141.51,124.2,141.74,127.58,141.73,127.96"/>
-<path class="st45" d="M188.94,124.88c-3.61-0.78-7.68-1.67-10.83,0.59c-2.41,1.73-3.88,4.89-3.72,8.88
-	c0.43,10.37,11.79,10.02,14.68,7.76l-0.96-3.74c-11.93,2.97-9.13-8.41-6.14-9.79c2.1-0.97,4.32-0.04,6.19,0.42L188.94,124.88z"/>
-<path class="st45" d="M101.15,124.87c-18.42-4.1-16.71,13.73-10.2,17.26c2.81,1.53,7.49,1.68,10.35,0.09l-0.84-3.94
-	c-4.51,1.31-8.51,1.29-8.71-4.32c-0.22-6.22,3.6-6.27,8.62-4.96L101.15,124.87z"/>
-<path class="st46" d="M110.46,128.57c-4.26,2.41-2.65,12.64,2.98,10.28C117.86,137,115.93,125.47,110.46,128.57"/>
-<path class="st46" d="M33.29,138.37c3.33,0.14,7.71,0.56,7.82-2.92c0.14-4.16-4.64-3.39-7.88-3.36L33.29,138.37z"/>
-<path class="st46" d="M33.31,128.06c3.24,0.1,6.76,0.63,6.83-2.82c0.08-3.51-3.85-3.32-6.89-3.14L33.31,128.06z"/>
-<path class="st46" d="M166.9,139.22c0.33-0.99,0.53-3.31-0.27-3.84c-0.91-0.6-3.51-0.29-4.3,0.46
-	C159.92,138.13,163.22,140.71,166.9,139.22"/>
-<path class="st46" d="M58.57,139.37c0.31-0.52,0.19-0.13,0.35-0.93l-0.21-3.09C51.01,133.94,52.22,141.24,58.57,139.37"/>
-<path class="st5" d="M19.79,3.22h193.03c8.52,0,15.5,6.97,15.5,15.5v137.02c0,8.52-6.97,15.5-15.5,15.5H19.79
-	c-8.52,0-15.5-6.97-15.5-15.5V18.71C4.29,10.19,11.26,3.22,19.79,3.22 M16.7,0h199.2c9.18,0,16.7,7.51,16.7,16.7v141.05
-	c0,9.18-7.51,16.7-16.7,16.7H16.7c-9.18,0-16.7-7.51-16.7-16.7V16.7C0,7.51,7.51,0,16.7,0z"/>
+<path d="M18.225 52.5223C17.995 52.369 17.736 52.2697 17.4486 52.2227C17.8417 52.1003 18.1393 51.8928 18.3397 51.6003C18.6303 51.1764 18.7759 50.6977 18.7759 50.1642C18.7759 49.6784 18.6593 49.2403 18.4254 48.8492C18.1915 48.4587 17.8558 48.1585 17.4177 47.9484C16.9796 47.7391 16.4745 47.634 15.9023 47.634H12.0005V57.4821H16.2026C16.8791 57.4821 17.4532 57.3487 17.9248 57.082C18.3964 56.8152 18.7443 56.4654 18.9679 56.0318C19.1915 55.5982 19.3036 55.1433 19.3036 54.6665C19.3036 54.2374 19.2127 53.8328 19.0323 53.4514C18.8513 53.0706 18.582 52.7607 18.225 52.5223ZM16.546 49.6784C16.7174 49.8788 16.8031 50.1403 16.8031 50.4644C16.8031 50.8072 16.7122 51.0746 16.5318 51.2646C16.3508 51.4554 16.1027 51.5507 15.7883 51.5507H13.9733V49.3781H15.7883C16.122 49.3781 16.3746 49.478 16.546 49.6784ZM17.1458 55.1027C17.0408 55.2979 16.8862 55.4532 16.6813 55.5672C16.4764 55.6813 16.2264 55.7386 15.9307 55.7386H13.9727V53.1943H15.9449C16.24 53.1943 16.4951 53.2562 16.7096 53.3799C16.9242 53.5036 17.0762 53.6608 17.1671 53.8515C17.2573 54.0422 17.303 54.2471 17.303 54.4661C17.303 54.6852 17.2509 54.9074 17.1458 55.1027Z" fill="#0B2265"/>
+<path d="M25.7532 51.6937C25.71 51.6273 25.663 51.5629 25.6101 51.5004C25.3718 51.2195 25.0715 51.0049 24.7094 50.8574C24.3473 50.7098 23.9659 50.6357 23.5658 50.6357C22.946 50.6357 22.3912 50.7859 21.9009 51.0861C21.41 51.3863 21.0266 51.8006 20.7502 52.3296C20.4738 52.8586 20.3359 53.4661 20.3359 54.1523C20.3359 54.8385 20.4738 55.446 20.7502 55.9744C21.0266 56.5033 21.408 56.9157 21.8938 57.2108C22.3796 57.5059 22.9279 57.6541 23.5374 57.6541C23.9375 57.6541 24.3235 57.5729 24.6952 57.4111C25.067 57.2494 25.3718 57.0207 25.6101 56.725C25.663 56.6599 25.71 56.5929 25.7532 56.5246V57.4827H27.6113V50.8078H25.7532V51.6937ZM25.4607 55.0311C25.3035 55.3024 25.0915 55.5195 24.8247 55.6812C24.558 55.8436 24.2674 55.9241 23.953 55.9241C23.6193 55.9241 23.3242 55.8436 23.0671 55.6812C22.81 55.5195 22.6045 55.3004 22.4524 55.024C22.2997 54.7476 22.2237 54.4571 22.2237 54.1523C22.2237 53.8282 22.2997 53.5306 22.4524 53.2587C22.6045 52.9874 22.81 52.7703 23.0671 52.6086C23.3242 52.4469 23.6199 52.3657 23.953 52.3657C24.2578 52.3657 24.5438 52.4443 24.8106 52.6015C25.0773 52.7587 25.2919 52.9732 25.4536 53.2445C25.6153 53.5157 25.6965 53.8186 25.6965 54.1523C25.6965 54.4667 25.6179 54.7599 25.4607 55.0311Z" fill="#0B2265"/>
+<path d="M34.5746 51.0146C34.179 50.762 33.6958 50.6357 33.1237 50.6357C32.8473 50.6357 32.5496 50.7002 32.23 50.829C31.9105 50.9579 31.6347 51.1486 31.4008 51.4005C31.2681 51.5442 31.1714 51.7046 31.1077 51.8805V50.8078H29.2495V57.4827H31.1077V53.9809C31.1077 53.5905 31.1837 53.278 31.3364 53.0448C31.4884 52.8115 31.6772 52.6447 31.9008 52.5448C32.1244 52.4449 32.3653 52.3947 32.6224 52.3947C32.8511 52.3947 33.0631 52.452 33.2583 52.566C33.4535 52.6807 33.6088 52.8521 33.7229 53.0808C33.8369 53.3096 33.8942 53.5905 33.8942 53.9242V57.4833H35.7666V53.8102C35.7666 53.1524 35.6667 52.586 35.4663 52.1092C35.2659 51.6331 34.9683 51.2684 34.5733 51.0159L34.5746 51.0146Z" fill="#0B2265"/>
+<path d="M41.3796 55.7456C41.1225 55.8648 40.8603 55.9241 40.5935 55.9241C40.2508 55.9241 39.9434 55.8455 39.6716 55.6883C39.3997 55.5311 39.1877 55.3146 39.0356 55.0382C38.8829 54.7618 38.8069 54.4571 38.8069 54.1233C38.8069 53.7896 38.8829 53.5041 39.0356 53.2374C39.1877 52.9707 39.3977 52.7587 39.6645 52.6015C39.9312 52.4443 40.2411 52.3657 40.5935 52.3657C40.8603 52.3657 41.1225 52.4275 41.3796 52.5512C41.6367 52.6749 41.8415 52.8373 41.9942 53.037L43.3808 52.0506C43.0567 51.6028 42.6566 51.2549 42.1804 51.0075C41.7037 50.7601 41.1702 50.6357 40.5794 50.6357C39.9215 50.6357 39.3165 50.7814 38.7644 51.0719C38.2116 51.3625 37.7664 51.7723 37.4281 52.3012C37.0899 52.8302 36.9204 53.4378 36.9204 54.1233C36.9204 54.8088 37.0892 55.4216 37.4281 55.9602C37.7664 56.4988 38.2142 56.9157 38.7715 57.2108C39.3288 57.5059 39.9312 57.6541 40.5794 57.6541C41.1702 57.6541 41.7037 57.5278 42.1804 57.2752C42.6566 57.0226 43.0618 56.6773 43.3956 56.2392L41.9949 55.2528C41.8422 55.4622 41.6367 55.6271 41.3796 55.7456Z" fill="#0B2265"/>
+<path d="M49.2469 51.079C48.6986 50.7839 48.1058 50.6357 47.4673 50.6357C46.8288 50.6357 46.238 50.7833 45.6949 51.079C45.1517 51.3747 44.7136 51.7865 44.3799 52.3154C44.0461 52.8444 43.8799 53.452 43.8799 54.1375C43.8799 54.823 44.0468 55.4338 44.3799 55.9673C44.713 56.5008 45.1517 56.9157 45.6949 57.2108C46.238 57.5059 46.8288 57.6541 47.4673 57.6541C48.1058 57.6541 48.6986 57.5065 49.2469 57.2108C49.7945 56.9157 50.2333 56.5008 50.5619 55.9673C50.8905 55.4338 51.0548 54.8237 51.0548 54.1375C51.0548 53.4513 50.8905 52.8437 50.5619 52.3154C50.2333 51.7865 49.7945 51.3747 49.2469 51.079ZM48.9395 55.0595C48.7868 55.3307 48.5819 55.5433 48.3249 55.6954C48.0678 55.8481 47.7862 55.9241 47.4815 55.9241C47.1574 55.9241 46.8668 55.8481 46.6098 55.6954C46.3527 55.5433 46.1472 55.3307 45.9951 55.0595C45.8424 54.7876 45.7664 54.4803 45.7664 54.1375C45.7664 53.7947 45.8424 53.4893 45.9951 53.2226C46.1472 52.9558 46.3527 52.7465 46.6098 52.5938C46.8668 52.4417 47.1477 52.365 47.4531 52.365C47.7772 52.365 48.0678 52.4417 48.3249 52.5938C48.5819 52.7465 48.7868 52.9584 48.9395 53.2297C49.0916 53.5016 49.1683 53.8037 49.1683 54.1375C49.1683 54.4712 49.0916 54.7876 48.9395 55.0595Z" fill="#0B2265"/>
+<path d="M57.6039 51.0146C57.2083 50.762 56.7251 50.6357 56.153 50.6357C55.8766 50.6357 55.5789 50.7002 55.2593 50.829C54.9397 50.9579 54.664 51.1486 54.4301 51.4005C54.2974 51.5442 54.2007 51.7046 54.137 51.8805V50.8078H52.2788V57.4827H54.137V53.9809C54.137 53.5905 54.213 53.278 54.3657 53.0448C54.5177 52.8115 54.7065 52.6447 54.9301 52.5448C55.1537 52.4449 55.3946 52.3947 55.6517 52.3947C55.8804 52.3947 56.0924 52.452 56.2876 52.566C56.4828 52.6807 56.6381 52.8521 56.7522 53.0808C56.8662 53.3096 56.9235 53.5905 56.9235 53.9242V57.4833H58.7959V53.8102C58.7959 53.1524 58.696 52.586 58.4956 52.1092C58.2952 51.6331 57.9976 51.2684 57.6026 51.0159L57.6039 51.0146Z" fill="#0B2265"/>
+<path d="M62.6719 48.3774H60.7996V50.8071H59.5986V52.2509H60.7996V57.482H62.6719V52.2509H64.0868V50.8071H62.6719V48.3774Z" fill="#0B2265"/>
+<path d="M70.0251 51.6937C69.982 51.6273 69.9349 51.5629 69.8821 51.5004C69.6437 51.2195 69.3435 51.0049 68.9814 50.8574C68.6193 50.7098 68.2379 50.6357 67.8378 50.6357C67.218 50.6357 66.6632 50.7859 66.1729 51.0861C65.682 51.3863 65.2986 51.8006 65.0222 52.3296C64.7458 52.8586 64.6079 53.4661 64.6079 54.1523C64.6079 54.8385 64.7458 55.446 65.0222 55.9744C65.2986 56.5033 65.68 56.9157 66.1658 57.2108C66.6516 57.5059 67.1999 57.6541 67.8094 57.6541C68.2095 57.6541 68.5955 57.5729 68.9672 57.4111C69.339 57.2494 69.6437 57.0207 69.8821 56.725C69.9349 56.6599 69.982 56.5929 70.0251 56.5246V57.4827H71.8833V50.8078H70.0251V51.6937ZM69.7326 55.0311C69.5754 55.3024 69.3635 55.5195 69.0967 55.6812C68.83 55.8436 68.5394 55.9241 68.225 55.9241C67.8912 55.9241 67.5962 55.8436 67.3391 55.6812C67.082 55.5195 66.8771 55.3004 66.7244 55.024C66.5717 54.7476 66.4957 54.4571 66.4957 54.1523C66.4957 53.8282 66.5717 53.5306 66.7244 53.2587C66.8765 52.9874 67.082 52.7703 67.3391 52.6086C67.5962 52.4469 67.8919 52.3657 68.225 52.3657C68.5297 52.3657 68.8158 52.4443 69.0825 52.6015C69.3493 52.7587 69.5638 52.9732 69.7256 53.2445C69.8873 53.5157 69.9685 53.8186 69.9685 54.1523C69.9685 54.4667 69.8898 54.7599 69.7326 55.0311Z" fill="#0B2265"/>
+<path d="M77.5935 55.7456C77.3364 55.8648 77.0741 55.9241 76.8074 55.9241C76.4646 55.9241 76.1573 55.8455 75.8854 55.6883C75.6135 55.5311 75.4016 55.3146 75.2495 55.0382C75.0968 54.7618 75.0208 54.4571 75.0208 54.1233C75.0208 53.7896 75.0968 53.5041 75.2495 53.2374C75.4016 52.9707 75.6116 52.7587 75.8783 52.6015C76.1451 52.4443 76.455 52.3657 76.8074 52.3657C77.0741 52.3657 77.3364 52.4275 77.5935 52.5512C77.8505 52.6749 78.0554 52.8373 78.2081 53.037L79.5946 52.0506C79.2705 51.6028 78.8704 51.2549 78.3943 51.0075C77.9175 50.7601 77.3841 50.6357 76.7932 50.6357C76.1361 50.6357 75.5304 50.7814 74.9783 51.0719C74.4255 51.3625 73.9802 51.7723 73.642 52.3012C73.3037 52.8302 73.1343 53.4378 73.1343 54.1233C73.1343 54.8088 73.3031 55.4216 73.642 55.9602C73.9802 56.4988 74.428 56.9157 74.9853 57.2108C75.5427 57.5059 76.1451 57.6541 76.7932 57.6541C77.3841 57.6541 77.9175 57.5278 78.3943 57.2752C78.8704 57.0226 79.2757 56.6773 79.6094 56.2392L78.2087 55.2528C78.056 55.4622 77.8506 55.6271 77.5935 55.7456Z" fill="#0B2265"/>
+<path d="M84.7675 50.8071H83.3526V48.3774H81.4803V50.8071H80.2793V52.2509H81.4803V57.482H83.3526V52.2509H84.7675V50.8071Z" fill="#0B2265"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_95_259" x1="48.4463" y1="19.3223" x2="84.8928" y2="19.3223" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF9700"/>
+<stop offset="0.75" stop-color="#FFD400"/>
+<stop offset="1" stop-color="#FFD400"/>
+</linearGradient>
+<linearGradient id="paint1_linear_95_259" x1="12.1233" y1="33.8251" x2="48.2508" y2="33.8251" gradientUnits="userSpaceOnUse">
+<stop stop-color="#0439D1"/>
+<stop offset="0.25" stop-color="#0439D1"/>
+<stop offset="1" stop-color="#0B2265"/>
+</linearGradient>
+<clipPath id="clip0_95_259">
+<rect width="96" height="72" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/src/Gateways/Ideal/IdealGateway.php
+++ b/src/Gateways/Ideal/IdealGateway.php
@@ -17,46 +17,6 @@ class IdealGateway extends AbstractPaymentGateway
         $this->setIcon('svg/ideal-wero.svg');
 
         parent::__construct();
-        $settings = $this->settings ?? [];
-        $optionKey = 'woocommerce_buckaroo_ideal_settings';
-        $rawSettings = get_option($optionKey);
-
-        // Normalize title both in runtime and (if needed) in stored settings,
-        // but only when merchants are still using legacy or empty values.
-        $needsUpdate = false;
-
-        if (
-            ! isset($settings['title']) ||
-            $settings['title'] === '' ||
-            $settings['title'] === 'iDEAL'
-        ) {
-            $this->title = 'iDEAL | Wero';
-            if (is_array($rawSettings)) {
-                $rawSettings['title'] = 'iDEAL | Wero';
-                $needsUpdate = true;
-            }
-        }
-
-        if (
-            ! isset($settings['description']) ||
-            $settings['description'] === '' ||
-            stripos($settings['description'], 'ideal') !== false
-        ) {
-            $this->description = sprintf(
-                __('Pay with %s', 'wc-buckaroo-bpe-gateway'),
-                $this->title
-            );
-
-            if (is_array($rawSettings)) {
-                $rawSettings['description'] = $this->description;
-                $needsUpdate = true;
-            }
-        }
-
-        if ($needsUpdate && is_array($rawSettings)) {
-            update_option($optionKey, $rawSettings, 'no');
-        }
-
         $this->addRefundSupport();
         apply_filters('buckaroo_init_payment_class', $this);
     }

--- a/src/Install/Migration/MigrationHandler.php
+++ b/src/Install/Migration/MigrationHandler.php
@@ -8,6 +8,7 @@ use Buckaroo\Woocommerce\Install\Migration\Versions\SetupTransactionsAndLogs;
 use Buckaroo\Woocommerce\Services\Logger;
 use Throwable;
 use Buckaroo\Woocommerce\Install\Migration\Versions\DisableAutoloadForSettings;
+use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateIdealToIdealWero;
 
 /**
  * Core class for handling migrations
@@ -185,6 +186,7 @@ class MigrationHandler
         return [
             new SetupTransactionsAndLogs(),
             new DisableAutoloadForSettings(),
+            new MigrateIdealToIdealWero(),
         ];
     }
 

--- a/src/Install/Migration/Versions/MigrateIdealToIdealWero.php
+++ b/src/Install/Migration/Versions/MigrateIdealToIdealWero.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Buckaroo\Woocommerce\Install\Migration\Versions;
+
+use Buckaroo\Woocommerce\Install\Migration\Migration;
+
+class MigrateIdealToIdealWero implements Migration
+{
+    public $version = '4.7.0';
+
+    public function execute()
+    {
+        $optionKey = 'woocommerce_buckaroo_ideal_settings';
+        $settings = get_option($optionKey);
+
+        if (! is_array($settings)) {
+            return;
+        }
+
+        $needsUpdate = false;
+
+        // Migrate legacy title "iDEAL" to "iDEAL | Wero"
+        if (isset($settings['title']) && $settings['title'] === 'iDEAL') {
+            $settings['title'] = 'iDEAL | Wero';
+            $needsUpdate = true;
+        }
+
+        // Reset legacy description so getPaymentDescription() regenerates it
+        // with proper translation support
+        if (
+            isset($settings['description']) &&
+            in_array($settings['description'], [
+                'Pay with iDEAL',
+                'Betaal met iDEAL',
+                'Zahlen mit iDEAL',
+                'Payer avec iDEAL',
+            ], true)
+        ) {
+            $settings['description'] = '';
+            $needsUpdate = true;
+        }
+
+        if ($needsUpdate) {
+            update_option($optionKey, $settings, 'no');
+        }
+    }
+}

--- a/tests/Test_MigrateIdealToIdealWero.php
+++ b/tests/Test_MigrateIdealToIdealWero.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateIdealToIdealWero;
+use PHPUnit\Framework\TestCase;
+
+// Stub WordPress functions for unit testing
+if (! function_exists('get_option')) {
+    function get_option(string $key, $default = false)
+    {
+        global $wp_test_options;
+
+        return $wp_test_options[$key] ?? $default;
+    }
+}
+
+if (! function_exists('update_option')) {
+    function update_option(string $key, $value, $autoload = null): bool
+    {
+        global $wp_test_options;
+        $wp_test_options[$key] = $value;
+
+        return true;
+    }
+}
+
+class Test_MigrateIdealToIdealWero extends TestCase
+{
+    private const OPTION_KEY = 'woocommerce_buckaroo_ideal_settings';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        global $wp_test_options;
+        $wp_test_options = [];
+    }
+
+    protected function tearDown(): void
+    {
+        global $wp_test_options;
+        $wp_test_options = [];
+        parent::tearDown();
+    }
+
+    public function test_migration_implements_interface()
+    {
+        $migration = new MigrateIdealToIdealWero();
+        $this->assertInstanceOf(
+            \Buckaroo\Woocommerce\Install\Migration\Migration::class,
+            $migration
+        );
+    }
+
+    public function test_migration_version_is_set()
+    {
+        $migration = new MigrateIdealToIdealWero();
+        $this->assertEquals('4.7.0', $migration->version);
+    }
+
+    public function test_migrates_legacy_ideal_title_to_ideal_wero()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL',
+            'description' => 'Some custom description',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('iDEAL | Wero', $wp_test_options[self::OPTION_KEY]['title']);
+    }
+
+    public function test_preserves_custom_title()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'Betaal met iDEAL | Wero',
+            'description' => 'Custom description',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('Betaal met iDEAL | Wero', $wp_test_options[self::OPTION_KEY]['title']);
+    }
+
+    public function test_preserves_ideal_wero_title()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL | Wero',
+            'description' => 'Pay with iDEAL | Wero',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('iDEAL | Wero', $wp_test_options[self::OPTION_KEY]['title']);
+    }
+
+    public function test_resets_legacy_english_description()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL',
+            'description' => 'Pay with iDEAL',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('', $wp_test_options[self::OPTION_KEY]['description']);
+    }
+
+    public function test_resets_legacy_dutch_description()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL',
+            'description' => 'Betaal met iDEAL',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('', $wp_test_options[self::OPTION_KEY]['description']);
+    }
+
+    public function test_resets_legacy_german_description()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL',
+            'description' => 'Zahlen mit iDEAL',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('', $wp_test_options[self::OPTION_KEY]['description']);
+    }
+
+    public function test_resets_legacy_french_description()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL',
+            'description' => 'Payer avec iDEAL',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('', $wp_test_options[self::OPTION_KEY]['description']);
+    }
+
+    public function test_preserves_custom_description()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL | Wero',
+            'description' => 'My custom payment description',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('My custom payment description', $wp_test_options[self::OPTION_KEY]['description']);
+    }
+
+    public function test_preserves_new_format_description()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL | Wero',
+            'description' => 'Pay with iDEAL | Wero',
+            'enabled' => 'yes',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertEquals('Pay with iDEAL | Wero', $wp_test_options[self::OPTION_KEY]['description']);
+    }
+
+    public function test_skips_when_option_does_not_exist()
+    {
+        global $wp_test_options;
+        // Option not set — get_option returns false
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $this->assertArrayNotHasKey(self::OPTION_KEY, $wp_test_options);
+    }
+
+    public function test_preserves_other_settings()
+    {
+        global $wp_test_options;
+        $wp_test_options[self::OPTION_KEY] = [
+            'title' => 'iDEAL',
+            'description' => 'Pay with iDEAL',
+            'enabled' => 'yes',
+            'mode' => 'live',
+            'extrachargeamount' => '0',
+        ];
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        $settings = $wp_test_options[self::OPTION_KEY];
+        $this->assertEquals('yes', $settings['enabled']);
+        $this->assertEquals('live', $settings['mode']);
+        $this->assertEquals('0', $settings['extrachargeamount']);
+    }
+
+    public function test_no_update_when_nothing_to_migrate()
+    {
+        global $wp_test_options;
+        $original = [
+            'title' => 'iDEAL | Wero',
+            'description' => 'My custom description',
+            'enabled' => 'yes',
+        ];
+        $wp_test_options[self::OPTION_KEY] = $original;
+
+        (new MigrateIdealToIdealWero())->execute();
+
+        // Settings should be unchanged (no update_option call)
+        $this->assertEquals($original, $wp_test_options[self::OPTION_KEY]);
+    }
+}


### PR DESCRIPTION
- remove aggressive constructor normalization that overwrote saved title/description on every page load
- add one-time migration for legacy "iDEAL" to "iDEAL | Wero" title
- dutch translations now apply correctly since description is no longer force-regenerated in english