### PR TITLE
fix(BTI-665): use buckaroo ConsumerMessage for transfer instructions

### DIFF
--- a/src/Gateways/Transfer/TransferGateway.php
+++ b/src/Gateways/Transfer/TransferGateway.php
@@ -54,6 +54,25 @@ class TransferGateway extends AbstractPaymentGateway
             return;
         }
 
+        $consumerMessageHtml = get_post_meta($order->get_id(), 'buckaroo_consumerMessageHtml', true);
+
+        if (! empty($consumerMessageHtml)) {
+            echo '<section class="woocommerce-buckaroo-transfer-instructions">';
+            echo wp_kses(
+                $consumerMessageHtml,
+                [
+                    'table' => ['class' => true],
+                    'td' => ['class' => true, 'id' => true],
+                    'tr' => [],
+                    'br' => [],
+                    'b' => [],
+                ]
+            );
+            echo '</section>';
+
+            return;
+        }
+
         $amount            = wc_price($order->get_total(), ['currency' => $order->get_currency()]);
         $order_number      = $order->get_order_number();
         $payment_reference = get_post_meta($order->get_id(), 'buckaroo_paymentReference', true) ?: $order_number;

--- a/src/Gateways/Transfer/TransferResponse.php
+++ b/src/Gateways/Transfer/TransferResponse.php
@@ -64,6 +64,8 @@ class TransferResponse implements IGatewayResponse
                 }
             }
 
+            $this->saveConsumerMessage($order_id);
+
             return;
         }
 
@@ -93,6 +95,22 @@ class TransferResponse implements IGatewayResponse
 
         if ($val = $this->responseParser->getService('paymentreference')) {
             update_post_meta($order_id, 'buckaroo_paymentReference', $val);
+        }
+
+        $this->saveConsumerMessage($order_id);
+    }
+
+    protected function saveConsumerMessage(string $order_id): void
+    {
+        if ($val = $this->responseParser->get('ConsumerMessage.HtmlText')) {
+            $allowed_html = [
+                'table' => ['class' => true],
+                'td' => ['class' => true, 'id' => true],
+                'tr' => [],
+                'br' => [],
+                'b' => [],
+            ];
+            update_post_meta($order_id, 'buckaroo_consumerMessageHtml', wp_kses($val, $allowed_html));
         }
     }
 

--- a/tests/Test_MigrateIdealToIdealWero.php
+++ b/tests/Test_MigrateIdealToIdealWero.php
@@ -5,26 +5,6 @@ declare(strict_types=1);
 use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateIdealToIdealWero;
 use PHPUnit\Framework\TestCase;
 
-// Stub WordPress functions for unit testing
-if (! function_exists('get_option')) {
-    function get_option(string $key, $default = false)
-    {
-        global $wp_test_options;
-
-        return $wp_test_options[$key] ?? $default;
-    }
-}
-
-if (! function_exists('update_option')) {
-    function update_option(string $key, $value, $autoload = null): bool
-    {
-        global $wp_test_options;
-        $wp_test_options[$key] = $value;
-
-        return true;
-    }
-}
-
 class Test_MigrateIdealToIdealWero extends TestCase
 {
     private const OPTION_KEY = 'woocommerce_buckaroo_ideal_settings';
@@ -32,14 +12,12 @@ class Test_MigrateIdealToIdealWero extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        global $wp_test_options;
-        $wp_test_options = [];
+        delete_option(self::OPTION_KEY);
     }
 
     protected function tearDown(): void
     {
-        global $wp_test_options;
-        $wp_test_options = [];
+        delete_option(self::OPTION_KEY);
         parent::tearDown();
     }
 
@@ -60,154 +38,150 @@ class Test_MigrateIdealToIdealWero extends TestCase
 
     public function test_migrates_legacy_ideal_title_to_ideal_wero()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL',
             'description' => 'Some custom description',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('iDEAL | Wero', $wp_test_options[self::OPTION_KEY]['title']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('iDEAL | Wero', $settings['title']);
     }
 
     public function test_preserves_custom_title()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'Betaal met iDEAL | Wero',
             'description' => 'Custom description',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('Betaal met iDEAL | Wero', $wp_test_options[self::OPTION_KEY]['title']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('Betaal met iDEAL | Wero', $settings['title']);
     }
 
     public function test_preserves_ideal_wero_title()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL | Wero',
             'description' => 'Pay with iDEAL | Wero',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('iDEAL | Wero', $wp_test_options[self::OPTION_KEY]['title']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('iDEAL | Wero', $settings['title']);
     }
 
     public function test_resets_legacy_english_description()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL',
             'description' => 'Pay with iDEAL',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('', $wp_test_options[self::OPTION_KEY]['description']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('', $settings['description']);
     }
 
     public function test_resets_legacy_dutch_description()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL',
             'description' => 'Betaal met iDEAL',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('', $wp_test_options[self::OPTION_KEY]['description']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('', $settings['description']);
     }
 
     public function test_resets_legacy_german_description()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL',
             'description' => 'Zahlen mit iDEAL',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('', $wp_test_options[self::OPTION_KEY]['description']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('', $settings['description']);
     }
 
     public function test_resets_legacy_french_description()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL',
             'description' => 'Payer avec iDEAL',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('', $wp_test_options[self::OPTION_KEY]['description']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('', $settings['description']);
     }
 
     public function test_preserves_custom_description()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL | Wero',
             'description' => 'My custom payment description',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('My custom payment description', $wp_test_options[self::OPTION_KEY]['description']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('My custom payment description', $settings['description']);
     }
 
     public function test_preserves_new_format_description()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL | Wero',
             'description' => 'Pay with iDEAL | Wero',
             'enabled' => 'yes',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertEquals('Pay with iDEAL | Wero', $wp_test_options[self::OPTION_KEY]['description']);
+        $settings = get_option(self::OPTION_KEY);
+        $this->assertEquals('Pay with iDEAL | Wero', $settings['description']);
     }
 
     public function test_skips_when_option_does_not_exist()
     {
-        global $wp_test_options;
-        // Option not set — get_option returns false
-
         (new MigrateIdealToIdealWero())->execute();
 
-        $this->assertArrayNotHasKey(self::OPTION_KEY, $wp_test_options);
+        $this->assertFalse(get_option(self::OPTION_KEY));
     }
 
     public function test_preserves_other_settings()
     {
-        global $wp_test_options;
-        $wp_test_options[self::OPTION_KEY] = [
+        update_option(self::OPTION_KEY, [
             'title' => 'iDEAL',
             'description' => 'Pay with iDEAL',
             'enabled' => 'yes',
             'mode' => 'live',
             'extrachargeamount' => '0',
-        ];
+        ]);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        $settings = $wp_test_options[self::OPTION_KEY];
+        $settings = get_option(self::OPTION_KEY);
         $this->assertEquals('yes', $settings['enabled']);
         $this->assertEquals('live', $settings['mode']);
         $this->assertEquals('0', $settings['extrachargeamount']);
@@ -215,17 +189,15 @@ class Test_MigrateIdealToIdealWero extends TestCase
 
     public function test_no_update_when_nothing_to_migrate()
     {
-        global $wp_test_options;
         $original = [
             'title' => 'iDEAL | Wero',
             'description' => 'My custom description',
             'enabled' => 'yes',
         ];
-        $wp_test_options[self::OPTION_KEY] = $original;
+        update_option(self::OPTION_KEY, $original);
 
         (new MigrateIdealToIdealWero())->execute();
 
-        // Settings should be unchanged (no update_option call)
-        $this->assertEquals($original, $wp_test_options[self::OPTION_KEY]);
+        $this->assertEquals($original, get_option(self::OPTION_KEY));
     }
 }


### PR DESCRIPTION
- store Buckaroo's ConsumerMessage.HtmlText in order meta on transfer response
- render the pre-translated consumer message on the thank you page instead of hardcoded English strings
- fall back to structured bank details from order meta when no consumer message is available