### PR TITLE
BTI-717: fix pending refund stock not restoring

### DIFF
--- a/src/PaymentProcessors/Actions/RefundAction.php
+++ b/src/PaymentProcessors/Actions/RefundAction.php
@@ -6,6 +6,7 @@ use Buckaroo\Woocommerce\Gateways\AbstractRefundProcessor;
 use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
 use Buckaroo\Woocommerce\Services\BuckarooClient;
 use Buckaroo\Woocommerce\Services\Logger;
+use BuckarooDeps\Buckaroo\Resources\Constants\ResponseStatus;
 use BuckarooDeps\Buckaroo\Transaction\Response\TransactionResponse;
 use WC_Order;
 use WP_Error;
@@ -80,6 +81,24 @@ class RefundAction
             return true;
         }
 
+        if ($this->isPendingRefund($transactionResponse)) {
+            $this->order->add_order_note(
+                sprintf(
+                    __('Refund of %1$s is pending processing - Transaction ID: %2$s', 'wc-buckaroo-bpe-gateway'),
+                    wc_price($transactionResponse->get('AmountCredit')),
+                    $transactionResponse->getTransactionKey()
+                )
+            );
+            add_post_meta(
+                $this->order->get_id(),
+                '_refundbuckaroo' . $transactionResponse->getTransactionKey(),
+                'ok',
+                true
+            );
+
+            return true;
+        }
+
         $this->order->add_order_note(
             sprintf(
                 __(
@@ -91,5 +110,13 @@ class RefundAction
         );
 
         return new WP_Error('error_refund', __('Refund failed: ') . $transactionResponse->getSomeError());
+    }
+
+    private function isPendingRefund(TransactionResponse $transactionResponse): bool
+    {
+        $statusCode = $transactionResponse->getStatusCode();
+
+        return $transactionResponse->isPendingProcessing()
+            || $statusCode == ResponseStatus::BUCKAROO_STATUSCODE_PAYMENT_ON_HOLD;
     }
 }

--- a/tests/Test_RefundAction.php
+++ b/tests/Test_RefundAction.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Buckaroo\Woocommerce\PaymentProcessors\Actions\RefundAction;
+use BuckarooDeps\Buckaroo\Resources\Constants\ResponseStatus;
+use BuckarooDeps\Buckaroo\Transaction\Response\TransactionResponse;
+use PHPUnit\Framework\TestCase;
+
+class Test_RefundAction extends TestCase
+{
+    /**
+     * @dataProvider pendingStatusCodeProvider
+     */
+    public function test_finalize_returns_true_for_pending_refund_status(int $statusCode)
+    {
+        $refundAction = $this->createRefundAction();
+        $response = $this->createMockResponse($statusCode);
+
+        $result = $refundAction->finalize($response);
+
+        $this->assertTrue($result, "finalize() should return true for pending status $statusCode");
+    }
+
+    public function test_finalize_returns_true_for_success_status()
+    {
+        $refundAction = $this->createRefundAction();
+        $response = $this->createMockResponse(190);
+
+        $result = $refundAction->finalize($response);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_finalize_returns_wp_error_for_failed_status()
+    {
+        $refundAction = $this->createRefundAction();
+        $response = $this->createMockResponse(490);
+
+        $result = $refundAction->finalize($response);
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+    }
+
+    public function test_finalize_sets_refund_meta_for_pending_status()
+    {
+        $orderId = $this->createTestOrderId();
+        $refundAction = $this->createRefundAction($orderId);
+        $transactionKey = 'PENDING_TX_KEY_793';
+        $response = $this->createMockResponse(793, $transactionKey);
+
+        $refundAction->finalize($response);
+
+        $meta = get_post_meta($orderId, '_refundbuckaroo' . $transactionKey, true);
+        $this->assertEquals('ok', $meta, 'Pending refund should set _refundbuckaroo meta to prevent duplicate on push');
+    }
+
+    public function test_finalize_adds_pending_order_note()
+    {
+        $refundAction = $this->createRefundAction();
+        $response = $this->createMockResponse(793);
+
+        $order = $this->getOrderFromRefundAction($refundAction);
+        $order->expects($this->once())
+            ->method('add_order_note')
+            ->with($this->stringContains('pending processing'));
+
+        $refundAction->finalize($response);
+    }
+
+    public static function pendingStatusCodeProvider(): array
+    {
+        return [
+            'pending processing (791)' => [791],
+            'payment on hold (793)' => [793],
+        ];
+    }
+
+    private function createRefundAction(?int $orderId = null): RefundAction
+    {
+        $reflection = new \ReflectionClass(RefundAction::class);
+        $refundAction = $reflection->newInstanceWithoutConstructor();
+
+        $order = $this->createMock(\WC_Order::class);
+        $order->method('get_id')->willReturn($orderId ?? 99999);
+        $order->method('get_transaction_id')->willReturn('ORIG_TX_KEY');
+
+        $orderProp = $reflection->getProperty('order');
+        $orderProp->setAccessible(true);
+        $orderProp->setValue($refundAction, $order);
+
+        return $refundAction;
+    }
+
+    private function getOrderFromRefundAction(RefundAction $refundAction): \WC_Order|\PHPUnit\Framework\MockObject\MockObject
+    {
+        $reflection = new \ReflectionClass(RefundAction::class);
+        $orderProp = $reflection->getProperty('order');
+        $orderProp->setAccessible(true);
+
+        return $orderProp->getValue($refundAction);
+    }
+
+    private function createMockResponse(int $statusCode, string $transactionKey = 'TEST_TX_KEY'): TransactionResponse
+    {
+        $response = $this->getMockBuilder(TransactionResponse::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $response->method('isSuccess')->willReturn($statusCode === 190);
+        $response->method('isPendingProcessing')->willReturn($statusCode === 791);
+        $response->method('getStatusCode')->willReturn($statusCode);
+        $response->method('getTransactionKey')->willReturn($transactionKey);
+        $response->method('get')->willReturn('20.00');
+        $response->method('getSomeError')->willReturn('Test error');
+
+        return $response;
+    }
+
+    private function createTestOrderId(): int
+    {
+        return wp_insert_post([
+            'post_type' => 'shop_order',
+            'post_status' => 'wc-processing',
+        ]);
+    }
+}

--- a/tests/Test_RefundAction.php
+++ b/tests/Test_RefundAction.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\RefundAction;
-use BuckarooDeps\Buckaroo\Resources\Constants\ResponseStatus;
 use BuckarooDeps\Buckaroo\Transaction\Response\TransactionResponse;
 use PHPUnit\Framework\TestCase;
 
@@ -92,7 +91,7 @@ class Test_RefundAction extends TestCase
         return $refundAction;
     }
 
-    private function getOrderFromRefundAction(RefundAction $refundAction): \WC_Order|\PHPUnit\Framework\MockObject\MockObject
+    private function getOrderFromRefundAction(RefundAction $refundAction)
     {
         $reflection = new \ReflectionClass(RefundAction::class);
         $orderProp = $reflection->getProperty('order');


### PR DESCRIPTION
- handle pending refund status (793/791) in finalize() by returning success to woocommerce
- wc keeps the refund and stock changes instead of rolling them back
- later push notification becomes a no-op via existing dedup meta check