### PR TITLE
fix(BTI-685): use order methods for apple pay payment method title

### DIFF
--- a/src/Gateways/Applepay/ApplepayGateway.php
+++ b/src/Gateways/Applepay/ApplepayGateway.php
@@ -207,8 +207,8 @@ class ApplepayGateway extends AbstractPaymentGateway
                 $order->add_shipping($wc_methods[$selected_method_id]);
             }
 
-            update_post_meta($order->get_id(), '_payment_method', $this->id);
-            update_post_meta($order->get_id(), '_payment_method_title', $this->title);
+            $order->set_payment_method($this->id);
+            $order->set_payment_method_title($this->title);
             $this->setOrderContribution($order);
 
             $order->calculate_totals();


### PR DESCRIPTION
- replace `update_post_meta()` with `$order->set_payment_method()` / `$order->set_payment_method_title()` in Apple Pay gateway
- fixes payment method not showing in order info on WooCommerce 10.5.x (HPOS-compatible)
- verified no breaking changes in WC 10.5.0-10.5.3 affecting the plugin