### PR TITLE
fix(BTI-4): use global cart for apple pay discount compatibility

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ Plugin URI: http://www.buckaroo.nl
 Author: Buckaroo
 Author URI: http://www.buckaroo.nl
 Description: Buckaroo payment system plugin for WooCommerce.
-Version: 4.7.0
+Version: 4.7.1
 Text Domain: wc-buckaroo-bpe-gateway
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author: Buckaroo
 Tags: WooCommerce, payments, Buckaroo
 Requires at least: 5.3.18
 Tested up to: 6.9
-Stable tag: 4.7.0
+Stable tag: 4.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -79,6 +79,10 @@ The “Buckaroo Woocommerce Payments Plugin” has been translated into 3 locale
 [Translate “Buckaroo Woocommerce Payments Plugin” into your language.](https://translate.wordpress.org/projects/wp-plugins/wc-buckaroo-bpe-gateway/)
 
 == Changelog ==
+= 4.7.1 =
+Bug Fixes
+BTI-4 Fixed Apple Pay incorrect order amount when used with third-party discount plugins (e.g. Woo Discount Rules "Buy X Get Y").
+
 = 4.7.0 =
 Changelog:
 Improvements & New Features

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -16,7 +16,7 @@ class Plugin
      *
      * @var string
      */
-    public const VERSION = '4.7.0';
+    public const VERSION = '4.7.1';
 
     /**
      * Instance of PaymentGatewayRegistry.

--- a/src/Gateways/Applepay/ApplepayGateway.php
+++ b/src/Gateways/Applepay/ApplepayGateway.php
@@ -7,7 +7,6 @@ use Buckaroo\Woocommerce\Services\Helper;
 use Buckaroo\Woocommerce\Services\Logger;
 use Exception;
 use Throwable;
-use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Fee;
 use WC_Order_Item_Product;
@@ -229,10 +228,22 @@ class ApplepayGateway extends AbstractPaymentGateway
 
     private static function recreateCartFromItems($items)
     {
-        $cart = new WC_Cart();
+        $cart = WC()->cart;
+        $cart->empty_cart(false);
 
         $products = array_filter($items, function ($item) {
-            return isset($item['type']) && $item['type'] === 'product';
+            if (!isset($item['type']) || $item['type'] !== 'product') {
+                return false;
+            }
+
+            if (isset($item['id']) && isset($item['price']) && floatval($item['price']) == 0) {
+                $product = wc_get_product($item['id']);
+                if ($product && floatval($product->get_price()) > 0) {
+                    return false;
+                }
+            }
+
+            return true;
         });
 
         foreach ($products as $product_item) {


### PR DESCRIPTION
- use WC()->cart instead of standalone new WC_Cart() so discount plugin hooks fire during calculate_totals()
- filter out zero-price items from "Buy X Get Y" rules to prevent duplication when the plugin re-adds them
- fixes order total mismatch causing orders stuck on "Pending payment"
- bump version to 4.7.1