### PR TITLE
Bti 899 riverty missing image url issue

### DIFF
--- a/src/Gateways/Afterpay/AfterpayNewGateway.php
+++ b/src/Gateways/Afterpay/AfterpayNewGateway.php
@@ -31,8 +31,6 @@ class AfterpayNewGateway extends AbstractPaymentGateway
 
     public $country;
 
-    public $sendimageinfo;
-
     public $afterpaynewpayauthorize;
 
     public $customer_type;
@@ -156,17 +154,6 @@ class AfterpayNewGateway extends AbstractPaymentGateway
             'default' => 'pay',
         ];
 
-        $this->form_fields['sendimageinfo'] = [
-            'title' => __('Send image info', 'wc-buckaroo-bpe-gateway'),
-            'type' => 'select',
-            'description' => __('Image info will be sent to BPE gateway inside ImageUrl parameter', 'wc-buckaroo-bpe-gateway'),
-            'options' => [
-                '0' => 'No',
-                '1' => 'Yes',
-            ],
-            'default' => 'pay',
-            'desc_tip' => 'Product images are only shown when they are available in JPG or PNG format',
-        ];
         $this->form_fields['customer_type'] = [
             'title' => __('Riverty customer type', 'wc-buckaroo-bpe-gateway'),
             'type' => 'select',
@@ -232,7 +219,6 @@ class AfterpayNewGateway extends AbstractPaymentGateway
     {
         parent::setProperties();
         $this->afterpaynewpayauthorize = $this->get_option('afterpaynewpayauthorize');
-        $this->sendimageinfo = $this->get_option('sendimageinfo');
         $this->vattype = $this->get_option('vattype');
         $this->type = 'afterpay';
         $this->customer_type = $this->get_option('customer_type', self::CUSTOMER_TYPE_BOTH);

--- a/src/Order/OrderArticles.php
+++ b/src/Order/OrderArticles.php
@@ -227,7 +227,20 @@ class OrderArticles
 
     public function get_product_image($product)
     {
-        $src = get_the_post_thumbnail_url($product->get_id());
+        $src = '';
+
+        // Prefer a bounded WooCommerce image size so the width stays within
+        // Riverty's 100-1280px requirement instead of the (often oversized)
+        // original upload.
+        $image_id = $product->get_image_id();
+        if ($image_id) {
+            $src = wp_get_attachment_image_url($image_id, 'woocommerce_single');
+        }
+
+        if (! $src) {
+            $src = get_the_post_thumbnail_url($product->get_id());
+        }
+
         if (! $src) {
             $imgTag = $product->get_image();
             $doc = new DOMDocument();
@@ -244,16 +257,21 @@ class OrderArticles
             $src = substr($src, 0, strpos($src, '?'));
         }
 
+        // Best-effort validation: when the image can be read server-side, enforce
+        // Riverty's format and width constraints. When it cannot be read (e.g. the
+        // shop server cannot reach its own media URL, common on staging), still
+        // send the URL so Riverty can fetch and render the thumbnail itself.
         $srcInfo = $this->safe_remote_getimagesize($src);
-        if (! is_array($srcInfo)) {
-            return;
-        }
+        if (is_array($srcInfo)) {
+            $mimeAllowed = ! empty($srcInfo['mime']) && in_array($srcInfo['mime'], ['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
+            $widthAllowed = ! empty($srcInfo[0]) && ($srcInfo[0] >= 100) && ($srcInfo[0] <= 1280);
 
-        if (! empty($srcInfo['mime']) && in_array($srcInfo['mime'], ['image/png', 'image/jpeg', 'image/gif', 'image/webp'])) {
-            if (! empty($srcInfo[0]) && ($srcInfo[0] >= 100) && ($srcInfo[0] <= 1280)) {
-                return $src;
+            if (! $mimeAllowed || ! $widthAllowed) {
+                return;
             }
         }
+
+        return $src;
     }
 
     /**

--- a/src/Order/OrderArticles.php
+++ b/src/Order/OrderArticles.php
@@ -213,9 +213,11 @@ class OrderArticles
     {
         $data = [];
         if ($item->get_type() === 'line_item') {
-            $img = $this->get_product_image($item->get_order_item()->get_product());
-            if (! empty($img)) {
-                $data['imgUrl'] = $img;
+            if ($this->gateway->id === 'buckaroo_afterpaynew') {
+                $img = $this->get_product_image($item->get_order_item()->get_product());
+                if (! empty($img)) {
+                    $data['imageUrl'] = $img;
+                }
             }
             $data['url'] = get_permalink($item->get_id());
         }
@@ -225,12 +227,6 @@ class OrderArticles
 
     public function get_product_image($product)
     {
-        // Only run when the setting is explicitly enabled.
-
-        if ((string) $this->gateway->get_option('sendimageinfo') !== '1') {
-            return;
-        }
-
         $src = get_the_post_thumbnail_url($product->get_id());
         if (! $src) {
             $imgTag = $product->get_image();
@@ -253,7 +249,7 @@ class OrderArticles
             return;
         }
 
-        if (! empty($srcInfo['mime']) && in_array($srcInfo['mime'], ['image/png', 'image/jpeg'])) {
+        if (! empty($srcInfo['mime']) && in_array($srcInfo['mime'], ['image/png', 'image/jpeg', 'image/gif', 'image/webp'])) {
             if (! empty($srcInfo[0]) && ($srcInfo[0] >= 100) && ($srcInfo[0] <= 1280)) {
                 return $src;
             }


### PR DESCRIPTION
Riverty requests never included ImageUrl

- Fixed key mismatch (imgUrl → imageUrl) so the SDK actually sends ImageUrl.
- Removed the sendimageinfo setting; images are now sent by default for Riverty (like Magento 2).
