### PR TITLE
Fix release tag for 4.8.1

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ Plugin URI: http://www.buckaroo.nl
 Author: Buckaroo
 Author URI: http://www.buckaroo.nl
 Description: Buckaroo payment system plugin for WooCommerce.
-Version: 4.7.2
+Version: 4.8.1
 Text Domain: wc-buckaroo-bpe-gateway
 Domain Path: /languages
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author: Buckaroo
 Tags: WooCommerce, payments, Buckaroo
 Requires at least: 5.3.18
 Tested up to: 7.0
-Stable tag: 4.8.0
+Stable tag: 4.8.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,9 @@ The “Buckaroo Woocommerce Payments Plugin” has been translated into 3 locale
 [Translate “Buckaroo Woocommerce Payments Plugin” into your language.](https://translate.wordpress.org/projects/wp-plugins/wc-buckaroo-bpe-gateway/)
 
 == Changelog ==
+= 4.8.1 =
+Fix 4.8.1 release tag
+
 = 4.8.0 =
 Improvements & New Features
 BTI-902 Add support for WooCommerce 10.7.0 en WordPress 7.0

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ The “Buckaroo Woocommerce Payments Plugin” has been translated into 3 locale
 
 == Changelog ==
 = 4.8.1 =
-Fix 4.8.1 release tag
+Maintenance release: corrected version metadata; includes all 4.8.0 features
 
 = 4.8.0 =
 Improvements & New Features

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -16,7 +16,7 @@ class Plugin
      *
      * @var string
      */
-    public const VERSION = '4.8.0';
+    public const VERSION = '4.8.1';
 
     /**
      * Instance of PaymentGatewayRegistry.

--- a/src/Install/Migration/Versions/MigrateKlarnaPayLaterLabels.php
+++ b/src/Install/Migration/Versions/MigrateKlarnaPayLaterLabels.php
@@ -11,7 +11,7 @@ use Buckaroo\Woocommerce\Install\Migration\Migration;
  */
 class MigrateKlarnaPayLaterLabels implements Migration
 {
-    public $version = '4.8.0';
+    public $version = '4.8.1';
 
     public function execute()
     {


### PR DESCRIPTION
Maintenance release: corrected version metadata; includes all 4.8.0 features