### PR TITLE
Add capability and nonce validation to admin AJAX endpoints

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ Plugin URI: http://www.buckaroo.nl
 Author: Buckaroo
 Author URI: http://www.buckaroo.nl
 Description: Buckaroo payment system plugin for WooCommerce.
-Version: 4.8.1
+Version: 4.8.2
 Text Domain: wc-buckaroo-bpe-gateway
 Domain Path: /languages
 License: GPLv2 or later

--- a/library/js/util.js
+++ b/library/js/util.js
@@ -35,7 +35,7 @@ buckarooAdmin = {
                     action: 'buckaroo_test_credentials',
                     website_key,
                     secret_key,
-                    security: (typeof buckarooAdminAjax !== 'undefined' ? buckarooAdminAjax.nonce : ''),
+                    security: typeof buckarooAdminAjax !== 'undefined' ? buckarooAdminAjax.nonce : '',
                 },
                 function (response) {
                     alert(response);
@@ -58,7 +58,7 @@ buckarooAdmin = {
                     ajaxurl,
                     {
                         action: 'buckaroo_auto_configure',
-                        security: (typeof buckarooAdminAjax !== 'undefined' ? buckarooAdminAjax.nonce : ''),
+                        security: typeof buckarooAdminAjax !== 'undefined' ? buckarooAdminAjax.nonce : '',
                     },
                     function (response) {
                         alert(response);

--- a/library/js/util.js
+++ b/library/js/util.js
@@ -35,6 +35,7 @@ buckarooAdmin = {
                     action: 'buckaroo_test_credentials',
                     website_key,
                     secret_key,
+                    security: (typeof buckarooAdminAjax !== 'undefined' ? buckarooAdminAjax.nonce : ''),
                 },
                 function (response) {
                     alert(response);
@@ -53,10 +54,17 @@ buckarooAdmin = {
                     'Warning! This action will automatically enable payment methods in LIVE mode based on your active Buckaroo subscriptions. This will overwrite your current payment method settings. Are you sure you want to proceed?'
                 )
             ) {
-                jQuery.post(ajaxurl, { action: 'buckaroo_auto_configure' }, function (response) {
-                    alert(response);
-                    location.reload();
-                });
+                jQuery.post(
+                    ajaxurl,
+                    {
+                        action: 'buckaroo_auto_configure',
+                        security: (typeof buckarooAdminAjax !== 'undefined' ? buckarooAdminAjax.nonce : ''),
+                    },
+                    function (response) {
+                        alert(response);
+                        location.reload();
+                    }
+                );
             }
         });
     },

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author: Buckaroo
 Tags: WooCommerce, payments, Buckaroo
 Requires at least: 5.3.18
 Tested up to: 7.0
-Stable tag: 4.8.1
+Stable tag: 4.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -16,7 +16,7 @@ class Plugin
      *
      * @var string
      */
-    public const VERSION = '4.8.1';
+    public const VERSION = '4.8.2';
 
     /**
      * Instance of PaymentGatewayRegistry.

--- a/src/Gateways/Klarna/capture-form.php
+++ b/src/Gateways/Klarna/capture-form.php
@@ -195,7 +195,8 @@ $refunded_capture_ids = $this->get_refunded_captures($order->get_id());
                         capture_id: $(this).attr('data-capture-id'),
                         order_id: woocommerce_admin_meta_boxes.post_id,
                         reason: form.find('.bk-refund-reason input').val(),
-                        restock: form.find('.bk-refund-restock input').is(':checked')
+                        restock: form.find('.bk-refund-restock input').is(':checked'),
+                        security: woocommerce_admin_meta_boxes.order_item_nonce
                     }
 
                     $.post(ajaxurl, data, function (response) {

--- a/src/Gateways/PayPerEmail/PayPerEmailGateway.php
+++ b/src/Gateways/PayPerEmail/PayPerEmailGateway.php
@@ -272,6 +272,7 @@ class PayPerEmailGateway extends AbstractPaymentGateway
             'wp_ajax_buckaroo_send_admin_payperemail',
             function () {
                 $orderId = absint($_GET['order_id'] ?? 0);
+                $this->verifyAdminOrderActionRequest($orderId);
                 $this->process_payment($orderId);
                 wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=shop_order'));
                 exit;
@@ -291,6 +292,7 @@ class PayPerEmailGateway extends AbstractPaymentGateway
             'wp_ajax_buckaroo_create_paylink',
             function () {
                 $orderId = absint($_GET['order_id'] ?? 0);
+                $this->verifyAdminOrderActionRequest($orderId);
                 $this->usePayPerLink = true;
                 $this->process_payment($orderId);
 
@@ -298,5 +300,22 @@ class PayPerEmailGateway extends AbstractPaymentGateway
                 exit;
             }
         );
+    }
+
+    /**
+     * Verify the current user may run a PayPerEmail / PayLink action for the
+     * given order before processing the payment request.
+     */
+    private function verifyAdminOrderActionRequest(int $orderId): void
+    {
+        if (! current_user_can('edit_shop_order', $orderId) && ! current_user_can('edit_shop_orders')) {
+            wp_die(
+                esc_html__('You are not allowed to perform this action.', 'wc-buckaroo-bpe-gateway'),
+                '',
+                ['response' => 403]
+            );
+        }
+
+        check_admin_referer('buckaroo_send_payperemail_' . $orderId);
     }
 }

--- a/src/Hooks/OrderActions.php
+++ b/src/Hooks/OrderActions.php
@@ -45,6 +45,30 @@ class OrderActions
 
     public function handleOrderCapture(): void
     {
+        if (! check_ajax_referer('order-item', 'security', false)) {
+            wp_send_json(
+                [
+                    'errors' => [
+                        'error_capture' => [
+                            [esc_html__('Invalid security token. Please reload the page and try again.', 'wc-buckaroo-bpe-gateway')],
+                        ],
+                    ],
+                ]
+            );
+        }
+
+        if (! current_user_can('edit_shop_orders')) {
+            wp_send_json(
+                [
+                    'errors' => [
+                        'error_capture' => [
+                            [esc_html__('You are not allowed to capture this order.', 'wc-buckaroo-bpe-gateway')],
+                        ],
+                    ],
+                ]
+            );
+        }
+
         if (! isset($_POST['order_id'])) {
             wp_send_json(
                 [

--- a/src/Hooks/PaymentSetupScripts.php
+++ b/src/Hooks/PaymentSetupScripts.php
@@ -61,6 +61,14 @@ class PaymentSetupScripts
             Plugin::VERSION,
             true
         );
+
+        wp_localize_script(
+            'buckaroo_admin_utils_js',
+            'buckarooAdminAjax',
+            [
+                'nonce' => wp_create_nonce('buckaroo_admin_ajax'),
+            ]
+        );
     }
 
     public function initFrontendScripts()

--- a/src/Hooks/TestCredentials.php
+++ b/src/Hooks/TestCredentials.php
@@ -13,6 +13,12 @@ class TestCredentials
 
     public function handle(): void
     {
+        if (! current_user_can('manage_woocommerce')) {
+            wp_die(esc_html__('You are not allowed to perform this action.', 'wc-buckaroo-bpe-gateway'), '', ['response' => 403]);
+        }
+
+        check_ajax_referer('buckaroo_admin_ajax', 'security');
+
         if (! isset($_POST['website_key']) || ! is_string($_POST['website_key'])) {
             wp_die(esc_html__('Credentials are incorrect', 'wc-buckaroo-bpe-gateway'));
         }

--- a/src/Order/OrderCaptureRefund.php
+++ b/src/Order/OrderCaptureRefund.php
@@ -35,6 +35,22 @@ class OrderCaptureRefund
      */
     public function refund_capture()
     {
+        if (! check_ajax_referer('order-item', 'security', false)) {
+            wp_send_json(
+                [
+                    'error' => __('Invalid security token. Please reload the page and try again.', 'wc-buckaroo-bpe-gateway'),
+                ]
+            );
+        }
+
+        if (! current_user_can('edit_shop_orders')) {
+            wp_send_json(
+                [
+                    'error' => __('You are not allowed to refund this order.', 'wc-buckaroo-bpe-gateway'),
+                ]
+            );
+        }
+
         $request = new Request();
         if ($request->input('order_id') === null) {
             wp_send_json(

--- a/src/Services/AutoConfiguration.php
+++ b/src/Services/AutoConfiguration.php
@@ -25,6 +25,12 @@ class AutoConfiguration
      */
     public function handleAjaxRequest()
     {
+        if (! current_user_can('manage_woocommerce')) {
+            wp_die(esc_html__('You are not allowed to perform this action.', 'wc-buckaroo-bpe-gateway'), '', ['response' => 403]);
+        }
+
+        check_ajax_referer('buckaroo_admin_ajax', 'security');
+
         try {
             $activeServices = $this->getActiveSubscriptions();
 

--- a/templates/capture-form.php
+++ b/templates/capture-form.php
@@ -195,7 +195,8 @@ $refunded_capture_ids = $this->get_refunded_captures($order->get_id());
                         capture_id: $(this).attr('data-capture-id'),
                         order_id: woocommerce_admin_meta_boxes.post_id,
                         reason: form.find('.bk-refund-reason input').val(),
-                        restock: form.find('.bk-refund-restock input').is(':checked')
+                        restock: form.find('.bk-refund-restock input').is(':checked'),
+                        security: woocommerce_admin_meta_boxes.order_item_nonce
                     }
 
                     $.post(ajaxurl, data, function (response) {


### PR DESCRIPTION
Add capability and nonce validation to admin AJAX endpoints

Enforce current_user_can() and nonce checks on the order capture,
capture refund, PayPerEmail/PayLink, credentials test, and auto-configure
AJAX handlers before processing. Send the order-item nonce from the
capture/refund forms and localize an admin nonce for the settings actions.