### PR TITLE
BTI-1229 Fix: Prevent adding a Buckaroo error twice to wc_add_notice() in classic/legacy layouts

### DIFF
--- a/src/Hooks/InitGateways.php
+++ b/src/Hooks/InitGateways.php
@@ -15,12 +15,6 @@ use Buckaroo\Woocommerce\Services\Helper;
 
 class InitGateways
 {
-
-    /**
-     * Buckaroo error added.
-     */
-    protected bool $error_notice_added = false;
-
     public function __construct()
     {
         add_action('enqueue_block_assets', [$this, 'initGatewaysOnCheckout']);
@@ -65,7 +59,6 @@ class InitGateways
 
     public function idinCheckout(): void
     {
-        $this->displayBuckarooErrors();
         if (IdinProcessor::isIdin(IdinProcessor::getCartProductIds())) {
             include plugin_dir_path(BK_PLUGIN_FILE) . 'templates/idin/checkout.php';
         }
@@ -85,13 +78,8 @@ class InitGateways
             return;
         }
 
-        if ($this->error_notice_added) {
-            return;
-        }
-
         if ($error = base64_decode($_GET['bck_err'])) {
             wc_add_notice(esc_html__(sanitize_text_field($error), 'wc-buckaroo-bpe-gateway'), 'error');
-            $this->error_notice_added = true;
         }
     }
 

--- a/src/Hooks/InitGateways.php
+++ b/src/Hooks/InitGateways.php
@@ -15,6 +15,12 @@ use Buckaroo\Woocommerce\Services\Helper;
 
 class InitGateways
 {
+
+    /**
+     * Buckaroo error added.
+     */
+    protected bool $error_notice_added = false;
+
     public function __construct()
     {
         add_action('enqueue_block_assets', [$this, 'initGatewaysOnCheckout']);
@@ -79,8 +85,13 @@ class InitGateways
             return;
         }
 
+        if ($this->error_notice_added) {
+            return;
+        }
+
         if ($error = base64_decode($_GET['bck_err'])) {
             wc_add_notice(esc_html__(sanitize_text_field($error), 'wc-buckaroo-bpe-gateway'), 'error');
+            $this->error_notice_added = true;
         }
     }
 


### PR DESCRIPTION
displayBuckarooErrors() can be called twice via template_redirect and idinCheckout, if the $_GET['bck_err'] is present an error wc_add_notice() is added twice, if that 2nd error is not rendered on page, it can be passed via ajax, redrawing the woocommerce cart