### PR TITLE
BTI-1245: add WooCommerce 11 and HPOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The [Buckaroo WooCommerce Payments Plugin](https://wordpress.org/plugins/wc-buck
 To use the Buckaroo plugin, please be aware of the following minimum requirements:
 - A Buckaroo account ([Dutch](https://www.buckaroo.nl/start) or [English](https://www.buckaroo.eu/solutions/request-form))
 - WordPress 5.3.18 up to 7.0
-- WooCommerce 5.0 up to 10.7.0
+- WooCommerce 5.0 up to 11.0.0
 - PHP 7.4, 8.0, 8.1, 8.2, 8.3, 8.4
 
 ### Quick installation

--- a/index.php
+++ b/index.php
@@ -6,7 +6,9 @@ Plugin URI: http://www.buckaroo.nl
 Author: Buckaroo
 Author URI: http://www.buckaroo.nl
 Description: Buckaroo payment system plugin for WooCommerce.
-Version: 4.9.0
+Version: 4.9.1
+WC requires at least: 5.0
+WC tested up to: 11.0.0
 Text Domain: wc-buckaroo-bpe-gateway
 Domain Path: /languages
 License: GPLv2 or later
@@ -35,6 +37,9 @@ add_action(
  * block "incompatibleExtensions" data), which is what triggers the Site Editor
  * notice suggesting merchants switch back to the Classic Checkout. The Buckaroo
  * gateways fully support the block checkout, so this declaration is correct.
+ *
+ * Order meta goes through Buckaroo\Woocommerce\Order\OrderMeta and older data is
+ * copied across by MigrateOrderMetaToHpos, so `custom_order_tables` is declared too.
  */
 add_action(
     'before_woocommerce_init',
@@ -42,6 +47,11 @@ add_action(
         if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
             \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
                 'cart_checkout_blocks',
+                BK_PLUGIN_FILE,
+                true
+            );
+            \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+                'custom_order_tables',
                 BK_PLUGIN_FILE,
                 true
             );

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,14 @@ The “Buckaroo Woocommerce Payments Plugin” has been translated into 3 locale
 [Translate “Buckaroo Woocommerce Payments Plugin” into your language.](https://translate.wordpress.org/projects/wp-plugins/wc-buckaroo-bpe-gateway/)
 
 == Changelog ==
+= 4.9.1 =
+Improvements
+BTI-1245 Added support for WooCommerce 11.0.
+BTI-1245 Order data is now stored through the WooCommerce order API, so the plugin works with High-Performance Order Storage. Existing orders are updated automatically in the background after the update.
+
+Bug Fixes
+BTI-1245 Resolved an issue where a new order could not be started after a failed payment on shops using High-Performance Order Storage.
+
 = 4.9.0 =
 Improvements & New Features
 BTI-777 Apple Pay is now visible across all web browsers and is also displayed as a separate checkout option alongside the Apple Pay buttons.

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -16,7 +16,7 @@ class Plugin
      *
      * @var string
      */
-    public const VERSION = '4.9.0';
+    public const VERSION = '4.9.1';
 
     /**
      * Instance of PaymentGatewayRegistry.

--- a/src/Gateways/AbstractPaymentGateway.php
+++ b/src/Gateways/AbstractPaymentGateway.php
@@ -7,6 +7,8 @@ use Buckaroo\Woocommerce\Gateways\Klarna\KlarnaKpGateway;
 use Buckaroo\Woocommerce\Gateways\Klarna\KlarnaPayGateway;
 use Buckaroo\Woocommerce\Order\OrderArticles;
 use Buckaroo\Woocommerce\Order\OrderDetails;
+use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateOrderMetaToHpos;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\CaptureAction;
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\PayAction;
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\RefundAction;
@@ -700,6 +702,10 @@ class AbstractPaymentGateway extends WC_Payment_Gateway
         }
 
         $order = Helper::findOrder($order_id);
+
+        // _wc_order_captures drives how much is still capturable.
+        MigrateOrderMetaToHpos::ensureOrderMigrated($order);
+
         $processor = $this->newPaymentProcessorInstance($order);
         $payment = new BuckarooClient($this->getMode());
 
@@ -863,8 +869,8 @@ class AbstractPaymentGateway extends WC_Payment_Gateway
      */
     protected function set_order_capture($order_id, $paymentName, $paymentType = null)
     {
-        update_post_meta($order_id, '_wc_order_selected_payment_method', $paymentName);
-        update_post_meta($order_id, '_wc_order_payment_issuer', $paymentType);
+        OrderMeta::update($order_id, '_wc_order_selected_payment_method', $paymentName);
+        OrderMeta::update($order_id, '_wc_order_payment_issuer', $paymentType);
     }
 
     public function getMode()

--- a/src/Gateways/AbstractRefundProcessor.php
+++ b/src/Gateways/AbstractRefundProcessor.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways;
 
 use Buckaroo\Woocommerce\Order\OrderDetails;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use WC_Order;
 
 class AbstractRefundProcessor extends AbstractProcessor
@@ -44,7 +45,7 @@ class AbstractRefundProcessor extends AbstractProcessor
     {
         $originalTransactionKey = (string) $this->getOrder()->get_transaction_id('edit');
 
-        $captures = get_post_meta($this->getOrder()->get_id(), '_wc_order_captures');
+        $captures = OrderMeta::get($this->getOrder(), '_wc_order_captures', false);
         if ($captures && !empty($captures)) {
             $lastCapture = end($captures);
             if (isset($lastCapture['transaction_id'])) {

--- a/src/Gateways/Afterpay/AfterpayNewGateway.php
+++ b/src/Gateways/Afterpay/AfterpayNewGateway.php
@@ -5,6 +5,7 @@ namespace Buckaroo\Woocommerce\Gateways\Afterpay;
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentGateway;
 use Buckaroo\Woocommerce\Gateways\AbstractProcessor;
 use Buckaroo\Woocommerce\Order\OrderDetails;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\Services\Helper;
 use Buckaroo\Woocommerce\Traits\HasDateValidation;
 use WC_Order;
@@ -134,7 +135,7 @@ class AfterpayNewGateway extends AbstractPaymentGateway
         $processedPayment = parent::process_payment($order_id);
 
         if (isset($processedPayment['result']) && $processedPayment['result'] == 'success' && $this->afterpaynewpayauthorize == 'authorize') {
-            update_post_meta($order_id, '_wc_order_authorized', 'yes');
+            OrderMeta::update($order_id, '_wc_order_authorized', 'yes');
             $this->set_order_capture($order_id, 'AfterpayNew');
         }
 
@@ -236,6 +237,6 @@ class AfterpayNewGateway extends AbstractPaymentGateway
             return false;
         }
 
-        return $this->afterpaynewpayauthorize == 'authorize' && get_post_meta($order->get_id(), '_wc_order_authorized', true) == 'yes';
+        return $this->afterpaynewpayauthorize == 'authorize' && OrderMeta::get($order, '_wc_order_authorized') == 'yes';
     }
 }

--- a/src/Gateways/Afterpay/AfterpayNewProcessor.php
+++ b/src/Gateways/Afterpay/AfterpayNewProcessor.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways\Afterpay;
 
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
 use BuckarooDeps\Buckaroo\Resources\Constants\ResponseStatus;
 
@@ -12,7 +13,7 @@ class AfterpayNewProcessor extends AbstractPaymentProcessor
     public function getAction(): string
     {
         if ($this->isAuthorization()) {
-            if (get_post_meta($this->get_order()->get_id(), '_wc_order_authorized', true) == 'yes') {
+            if (OrderMeta::get($this->get_order(), '_wc_order_authorized') == 'yes') {
                 return 'capture';
             }
 
@@ -151,7 +152,7 @@ class AfterpayNewProcessor extends AbstractPaymentProcessor
     protected function getBirthDate(string $country_code, string $type = 'billing'): array
     {
         if (in_array($country_code, ['NL', 'BE']) && ($birthDate = $this->getFormatedDate())) {
-            add_post_meta($this->get_order()->get_id(), '_payload_birthday', $birthDate, true);
+            OrderMeta::add($this->get_order(), '_payload_birthday', $birthDate, true);
 
             return [
                 $type => [
@@ -170,7 +171,7 @@ class AfterpayNewProcessor extends AbstractPaymentProcessor
      */
     private function getFormatedDate(): ?string
     {
-        $dateString = $this->request->input('buckaroo-afterpaynew-birthdate') ?: get_post_meta($this->get_order()->get_id(), '_payload_birthday', true);
+        $dateString = $this->request->input('buckaroo-afterpaynew-birthdate') ?: OrderMeta::get($this->get_order(), '_payload_birthday');
         if (! is_scalar($dateString)) {
             return null;
         }

--- a/src/Gateways/Afterpay/AfterpayOldGateway.php
+++ b/src/Gateways/Afterpay/AfterpayOldGateway.php
@@ -4,6 +4,7 @@ namespace Buckaroo\Woocommerce\Gateways\Afterpay;
 
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentGateway;
 use Buckaroo\Woocommerce\Gateways\AbstractProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\Services\Helper;
 use Buckaroo\Woocommerce\Traits\HasDateValidation;
 use WC_Order;
@@ -100,7 +101,7 @@ class AfterpayOldGateway extends AbstractPaymentGateway
         $processedPayment = parent::process_payment($order_id);
 
         if (isset($processedPayment['result']) && $processedPayment['result'] == 'success' && $this->afterpaypayauthorize == 'authorize') {
-            update_post_meta($order_id, '_wc_order_authorized', 'yes');
+            OrderMeta::update($order_id, '_wc_order_authorized', 'yes');
             $this->set_order_capture($order_id, 'Afterpay');
         }
 
@@ -180,6 +181,6 @@ class AfterpayOldGateway extends AbstractPaymentGateway
             return false;
         }
 
-        return $this->afterpaypayauthorize == 'authorize' && get_post_meta($order->get_id(), '_wc_order_authorized', true) == 'yes';
+        return $this->afterpaypayauthorize == 'authorize' && OrderMeta::get($order, '_wc_order_authorized') == 'yes';
     }
 }

--- a/src/Gateways/Afterpay/AfterpayOldProcessor.php
+++ b/src/Gateways/Afterpay/AfterpayOldProcessor.php
@@ -4,6 +4,7 @@ namespace Buckaroo\Woocommerce\Gateways\Afterpay;
 
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentProcessor;
 use Buckaroo\Woocommerce\Order\OrderDetails;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
 use BuckarooDeps\Buckaroo\Resources\Constants\ResponseStatus;
 use BuckarooDeps\Buckaroo\Transaction\Response\TransactionResponse;
@@ -13,7 +14,7 @@ class AfterpayOldProcessor extends AbstractPaymentProcessor
     public function getAction(): string
     {
         if ($this->isAuthorization()) {
-            if (get_post_meta($this->get_order()->get_id(), '_wc_order_authorized', true) == 'yes') {
+            if (OrderMeta::get($this->get_order(), '_wc_order_authorized') == 'yes') {
                 return 'capture';
             }
 

--- a/src/Gateways/CreditCard/CreditCardGateway.php
+++ b/src/Gateways/CreditCard/CreditCardGateway.php
@@ -4,6 +4,7 @@ namespace Buckaroo\Woocommerce\Gateways\CreditCard;
 
 use Buckaroo\Woocommerce\Core\Plugin;
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentGateway;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\Services\Helper;
 use WC_Order;
 
@@ -177,7 +178,7 @@ class CreditCardGateway extends AbstractPaymentGateway
         $processedPayment = parent::process_payment($order_id);
 
         if (isset($processedPayment['result']) && $processedPayment['result'] == 'success' && $this->creditcardpayauthorize == 'authorize') {
-            update_post_meta($order_id, '_wc_order_authorized', 'yes');
+            OrderMeta::update($order_id, '_wc_order_authorized', 'yes');
             $this->set_order_capture($order_id, 'Creditcard', $this->request->input($this->id . '-creditcard-issuer'));
         }
 
@@ -344,6 +345,6 @@ class CreditCardGateway extends AbstractPaymentGateway
             return false;
         }
 
-        return $this->creditcardpayauthorize == 'authorize' && get_post_meta($order->get_id(), '_wc_order_authorized', true) == 'yes';
+        return $this->creditcardpayauthorize == 'authorize' && OrderMeta::get($order, '_wc_order_authorized') == 'yes';
     }
 }

--- a/src/Gateways/CreditCard/CreditCardProcessor.php
+++ b/src/Gateways/CreditCard/CreditCardProcessor.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways\CreditCard;
 
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 
 class CreditCardProcessor extends AbstractPaymentProcessor
 {
@@ -10,7 +11,7 @@ class CreditCardProcessor extends AbstractPaymentProcessor
     public function getAction(): string
     {
         if ($this->isAuthorization()) {
-            if (get_post_meta($this->get_order()->get_id(), '_wc_order_authorized', true) == 'yes') {
+            if (OrderMeta::get($this->get_order(), '_wc_order_authorized') == 'yes') {
                 return 'capture';
             }
 
@@ -39,12 +40,12 @@ class CreditCardProcessor extends AbstractPaymentProcessor
     protected function getMethodBody(): array
     {
         $body = [
-            'name' => strtolower($this->request->input($this->gateway->id . '-creditcard-issuer')) ?: get_post_meta($this->get_order()->get_id(), '_payment_method_transaction', true),
+            'name' => strtolower($this->request->input($this->gateway->id . '-creditcard-issuer')) ?: OrderMeta::get($this->get_order(), '_payment_method_transaction'),
         ];
 
         if ($this->isEncripted()) {
-            $encryptedData = $this->request->input($this->gateway->id . '-encrypted-data') ?: get_post_meta($this->get_order()->get_id(), '_payload_encrypted_card_data', true);
-            add_post_meta($this->get_order()->get_id(), '_payload_encrypted_card_data', $encryptedData, true);
+            $encryptedData = $this->request->input($this->gateway->id . '-encrypted-data') ?: OrderMeta::get($this->get_order(), '_payload_encrypted_card_data');
+            OrderMeta::add($this->get_order(), '_payload_encrypted_card_data', $encryptedData, true);
 
             $body['sessionId'] = $encryptedData;
         }

--- a/src/Gateways/CreditCard/CreditCardRefundProcessor.php
+++ b/src/Gateways/CreditCard/CreditCardRefundProcessor.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways\CreditCard;
 
 use Buckaroo\Woocommerce\Gateways\AbstractRefundProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 
 class CreditCardRefundProcessor extends AbstractRefundProcessor
 {
@@ -10,7 +11,7 @@ class CreditCardRefundProcessor extends AbstractRefundProcessor
     protected function getMethodBody(): array
     {
         return [
-            'name' => get_post_meta($this->getOrder()->get_id(), '_payment_method_transaction', true),
+            'name' => OrderMeta::get($this->getOrder(), '_payment_method_transaction'),
         ];
     }
 }

--- a/src/Gateways/Klarna/KlarnaCancelReservation.php
+++ b/src/Gateways/Klarna/KlarnaCancelReservation.php
@@ -2,6 +2,7 @@
 
 namespace Buckaroo\Woocommerce\Gateways\Klarna;
 
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use WC_Order;
 
 /**
@@ -45,7 +46,7 @@ class KlarnaCancelReservation
 
         if (
             $order->get_payment_method() === 'buckaroo_klarnakp' &&
-            get_post_meta($order->get_id(), 'buckaroo_is_reserved', true) === 'yes'
+            OrderMeta::get($order, 'buckaroo_is_reserved') === 'yes'
         ) {
             $actions['buckaroo_klarnakp_cancel_reservation'] = esc_html__('Cancel reservation', 'woocommerce');
         }

--- a/src/Gateways/Klarna/KlarnaKpGateway.php
+++ b/src/Gateways/Klarna/KlarnaKpGateway.php
@@ -2,6 +2,7 @@
 
 namespace Buckaroo\Woocommerce\Gateways\Klarna;
 
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\CancelReservationAction;
 use Buckaroo\Woocommerce\Services\BuckarooClient;
 use Buckaroo\Woocommerce\Services\Helper;
@@ -42,10 +43,9 @@ class KlarnaKpGateway extends KlarnaGateway
         $processor = $this->newPaymentProcessorInstance($order);
         $payment = new BuckarooClient($this->getMode());
 
-        $reservation_number = get_post_meta(
-            $order->get_id(),
-            '_buckaroo_klarnakp_reservation_number',
-            true
+        $reservation_number = OrderMeta::get(
+            $order,
+            '_buckaroo_klarnakp_reservation_number'
         );
 
         if (! is_string($reservation_number) || strlen($reservation_number) === 0) {
@@ -76,7 +76,7 @@ class KlarnaKpGateway extends KlarnaGateway
         $processedPayment = parent::process_payment($order_id);
 
         if (isset($processedPayment['result']) && $processedPayment['result'] == 'success') {
-            update_post_meta($order_id, '_wc_order_authorized', 'yes');
+            OrderMeta::update($order_id, '_wc_order_authorized', 'yes');
             $this->setOrderCapture($order_id, 'KlarnaKp');
         }
 
@@ -93,7 +93,7 @@ class KlarnaKpGateway extends KlarnaGateway
      */
     protected function setOrderCapture($order_id, $paymentName, $paymentType = null)
     {
-        update_post_meta($order_id, '_wc_order_selected_payment_method', $paymentName);
+        OrderMeta::update($order_id, '_wc_order_selected_payment_method', $paymentName);
         $this->setOrderIssuer($order_id, $paymentType);
     }
 
@@ -109,7 +109,7 @@ class KlarnaKpGateway extends KlarnaGateway
         if (is_null($paymentType)) {
             $paymentType = $this->type;
         }
-        update_post_meta($order_id, '_wc_order_payment_issuer', $paymentType);
+        OrderMeta::update($order_id, '_wc_order_payment_issuer', $paymentType);
     }
 
     /**
@@ -122,10 +122,9 @@ class KlarnaKpGateway extends KlarnaGateway
      */
     public function process_capture($order_id)
     {
-        $reservation_number = get_post_meta(
+        $reservation_number = OrderMeta::get(
             $order_id,
-            '_buckaroo_klarnakp_reservation_number',
-            true
+            '_buckaroo_klarnakp_reservation_number'
         );
 
         if (! is_string($reservation_number) || strlen($reservation_number) === 0) {

--- a/src/Gateways/Klarna/KlarnaKpProcessor.php
+++ b/src/Gateways/Klarna/KlarnaKpProcessor.php
@@ -5,6 +5,7 @@ namespace Buckaroo\Woocommerce\Gateways\Klarna;
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentProcessor;
 use Buckaroo\Woocommerce\Gateways\Afterpay\AfterpayNewGateway;
 use Buckaroo\Woocommerce\Order\OrderDetails;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
 use BuckarooDeps\Buckaroo\Resources\Constants\Gender;
 
@@ -14,7 +15,7 @@ class KlarnaKpProcessor extends AbstractPaymentProcessor
 
     public function getAction(): string
     {
-        if (get_post_meta($this->get_order()->get_id(), '_buckaroo_klarnakp_reservation_number', true)) {
+        if (OrderMeta::get($this->get_order(), '_buckaroo_klarnakp_reservation_number')) {
             return 'pay';
         }
 
@@ -23,10 +24,9 @@ class KlarnaKpProcessor extends AbstractPaymentProcessor
 
     protected function getMethodBody(): array
     {
-        $reservation_number = get_post_meta(
-            $this->get_order()->get_id(),
-            '_buckaroo_klarnakp_reservation_number',
-            true
+        $reservation_number = OrderMeta::get(
+            $this->get_order(),
+            '_buckaroo_klarnakp_reservation_number'
         );
 
         return array_merge_recursive(
@@ -143,8 +143,8 @@ class KlarnaKpProcessor extends AbstractPaymentProcessor
 
     public function beforeReturnHandler(ResponseParser $responseParser, string $redirectUrl)
     {
-        update_post_meta(
-            $this->get_order()->get_id(),
+        OrderMeta::update(
+            $this->get_order(),
             '_buckaroo_klarnakp_reservation_number',
             $responseParser->getService('reservationNumber')
         );

--- a/src/Gateways/Klarna/KlarnaPayGateway.php
+++ b/src/Gateways/Klarna/KlarnaPayGateway.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways\Klarna;
 
 use Buckaroo\Woocommerce\Gateways\AbstractProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\CancelReservationAction;
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\ExtendReservationAction;
 use Buckaroo\Woocommerce\Services\BuckarooClient;
@@ -64,7 +65,7 @@ class KlarnaPayGateway extends KlarnaGateway
         $processedPayment = parent::process_payment($order_id);
 
         if (isset($processedPayment['result']) && $processedPayment['result'] === 'success') {
-            update_post_meta($order_id, '_wc_order_authorized', 'yes');
+            OrderMeta::update($order_id, '_wc_order_authorized', 'yes');
             // Must match the registry key ('klarnapay') so the capture AJAX
             // handler can resolve the gateway via PaymentGatewayRegistry::newGatewayInstance().
             $this->set_order_capture($order_id, 'KlarnaPay', $this->type);
@@ -81,7 +82,7 @@ class KlarnaPayGateway extends KlarnaGateway
      */
     public function process_capture($order_id)
     {
-        $dataRequestKey = get_post_meta($order_id, KlarnaProcessor::DATA_REQUEST_META_KEY, true);
+        $dataRequestKey = OrderMeta::get($order_id, KlarnaProcessor::DATA_REQUEST_META_KEY);
 
         if (! is_string($dataRequestKey) || strlen($dataRequestKey) === 0) {
             return $this->create_capture_error(__('Cannot perform capture, Klarna Data Request key not found', 'wc-buckaroo-bpe-gateway'));
@@ -101,7 +102,7 @@ class KlarnaPayGateway extends KlarnaGateway
         $processor = $this->newPaymentProcessorInstance($order);
         $payment = new BuckarooClient($this->getMode());
 
-        $dataRequestKey = get_post_meta($order->get_id(), KlarnaProcessor::DATA_REQUEST_META_KEY, true);
+        $dataRequestKey = OrderMeta::get($order, KlarnaProcessor::DATA_REQUEST_META_KEY);
 
         if (! is_string($dataRequestKey) || strlen($dataRequestKey) === 0) {
             return $this->create_capture_error(__('Cannot cancel reservation, Klarna Data Request key not found', 'wc-buckaroo-bpe-gateway'));
@@ -132,7 +133,7 @@ class KlarnaPayGateway extends KlarnaGateway
         $processor = $this->newPaymentProcessorInstance($order);
         $payment = new BuckarooClient($this->getMode());
 
-        $dataRequestKey = get_post_meta($order->get_id(), KlarnaProcessor::DATA_REQUEST_META_KEY, true);
+        $dataRequestKey = OrderMeta::get($order, KlarnaProcessor::DATA_REQUEST_META_KEY);
 
         if (! is_string($dataRequestKey) || strlen($dataRequestKey) === 0) {
             return $this->create_capture_error(__('Cannot extend reservation, Klarna Data Request key not found', 'wc-buckaroo-bpe-gateway'));

--- a/src/Gateways/Klarna/KlarnaProcessor.php
+++ b/src/Gateways/Klarna/KlarnaProcessor.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways\Klarna;
 
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
 
 class KlarnaProcessor extends AbstractPaymentProcessor
@@ -23,7 +24,7 @@ class KlarnaProcessor extends AbstractPaymentProcessor
         );
 
         if ($this->isReserved()) {
-            $dataRequestKey = get_post_meta($this->get_order()->get_id(), self::DATA_REQUEST_META_KEY, true);
+            $dataRequestKey = OrderMeta::get($this->get_order(), self::DATA_REQUEST_META_KEY);
 
             if (is_string($dataRequestKey) && strlen($dataRequestKey) > 0) {
                 // Klarna's `klarna` service identifies a reservation by a service-level
@@ -81,17 +82,18 @@ class KlarnaProcessor extends AbstractPaymentProcessor
         $dataRequestKey = $responseParser->getDataRequest();
 
         if (is_string($dataRequestKey) && strlen($dataRequestKey) > 0) {
-            update_post_meta($this->get_order()->get_id(), self::DATA_REQUEST_META_KEY, $dataRequestKey);
+            $order = $this->get_order();
+            OrderMeta::update($order, self::DATA_REQUEST_META_KEY, $dataRequestKey);
 
             if ($this->isResponseReserved($responseParser)) {
-                update_post_meta($this->get_order()->get_id(), 'buckaroo_is_reserved', 'yes');
+                OrderMeta::update($order, 'buckaroo_is_reserved', 'yes');
             }
         }
     }
 
     private function isReserved(): bool
     {
-        return get_post_meta($this->get_order()->get_id(), 'buckaroo_is_reserved', true) === 'yes';
+        return OrderMeta::get($this->get_order(), 'buckaroo_is_reserved') === 'yes';
     }
 
     private function isResponseReserved(ResponseParser $responseParser): bool

--- a/src/Gateways/Wero/WeroGateway.php
+++ b/src/Gateways/Wero/WeroGateway.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways\Wero;
 
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentGateway;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\Services\Helper;
 use WC_Order;
 
@@ -58,7 +59,7 @@ class WeroGateway extends AbstractPaymentGateway
             $processedPayment['result'] === 'success' &&
             $this->weropayauthorize === 'authorize'
         ) {
-            update_post_meta($order_id, '_wc_order_authorized', 'yes');
+            OrderMeta::update($order_id, '_wc_order_authorized', 'yes');
             $this->set_order_capture($order_id, 'Wero');
         }
 
@@ -99,6 +100,6 @@ class WeroGateway extends AbstractPaymentGateway
         }
 
         return $this->weropayauthorize === 'authorize' &&
-            get_post_meta($order->get_id(), '_wc_order_authorized', true) === 'yes';
+            OrderMeta::get($order, '_wc_order_authorized') === 'yes';
     }
 }

--- a/src/Gateways/Wero/WeroProcessor.php
+++ b/src/Gateways/Wero/WeroProcessor.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways\Wero;
 
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 
 class WeroProcessor extends AbstractPaymentProcessor
 {
@@ -15,7 +16,7 @@ class WeroProcessor extends AbstractPaymentProcessor
     {
         if ($this->isAuthorizationFlowEnabled()) {
             // If the order is already authorized, subsequent calls should capture.
-            if (get_post_meta($this->get_order()->get_id(), '_wc_order_authorized', true) === 'yes') {
+            if (OrderMeta::get($this->get_order(), '_wc_order_authorized') === 'yes') {
                 return 'capture';
             }
 

--- a/src/Gateways/Wero/WeroRefundProcessor.php
+++ b/src/Gateways/Wero/WeroRefundProcessor.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\Gateways\Wero;
 
 use Buckaroo\Woocommerce\Gateways\AbstractRefundProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 
 class WeroRefundProcessor extends AbstractRefundProcessor
 {
@@ -15,8 +16,8 @@ class WeroRefundProcessor extends AbstractRefundProcessor
     {
         $order = $this->getOrder();
 
-        $isAuthorized = get_post_meta($order->get_id(), '_wc_order_authorized', true) === 'yes';
-        $isCaptured = (bool) get_post_meta($order->get_id(), '_wc_order_is_captured', true);
+        $isAuthorized = OrderMeta::get($order, '_wc_order_authorized') === 'yes';
+        $isCaptured = (bool) OrderMeta::get($order, '_wc_order_is_captured');
 
         if ($isAuthorized && ! $isCaptured) {
             // This must match the Buckaroo SDK method name on the Wero payment method.

--- a/src/Hooks/OrderActions.php
+++ b/src/Hooks/OrderActions.php
@@ -5,6 +5,7 @@ namespace Buckaroo\Woocommerce\Hooks;
 use Buckaroo\Woocommerce\Core\PaymentGatewayRegistry;
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentGateway;
 use Buckaroo\Woocommerce\Order\OrderCaptureRefund;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\Services\Helper;
 use WC_Cart;
 
@@ -31,9 +32,10 @@ class OrderActions
             return;
         }
 
-        $orderId = $isOrderInstance ? $post->get_id() : $post->ID;
+        // Under HPOS the admin passes the order itself, not a post.
+        $order = $isOrderInstance ? $post : $post->ID;
 
-        if (get_post_meta($orderId, '_buckaroo_order_in_test_mode', true) !== '1') {
+        if (OrderMeta::get($order, '_buckaroo_order_in_test_mode') !== '1') {
             return;
         }
 
@@ -124,7 +126,7 @@ class OrderActions
     {
         $registry = new PaymentGatewayRegistry();
 
-        $primary = get_post_meta($orderId, '_wc_order_selected_payment_method', true);
+        $primary = OrderMeta::get($orderId, '_wc_order_selected_payment_method');
         if (is_string($primary) && $primary !== '') {
             $gateway = $registry->newGatewayInstance($primary);
             if ($gateway instanceof AbstractPaymentGateway) {

--- a/src/Install/Migration/MigrationHandler.php
+++ b/src/Install/Migration/MigrationHandler.php
@@ -10,6 +10,7 @@ use Throwable;
 use Buckaroo\Woocommerce\Install\Migration\Versions\DisableAutoloadForSettings;
 use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateIdealToIdealWero;
 use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateKlarnaPayLaterLabels;
+use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateOrderMetaToHpos;
 
 /**
  * Core class for handling migrations
@@ -50,6 +51,8 @@ class MigrationHandler
             10,
             2
         );
+        // Batched callback: must be registered on every request, not only on upgrade.
+        MigrateOrderMetaToHpos::registerBatchHandler();
     }
 
     /**
@@ -189,6 +192,7 @@ class MigrationHandler
             new DisableAutoloadForSettings(),
             new MigrateIdealToIdealWero(),
             new MigrateKlarnaPayLaterLabels(),
+            new MigrateOrderMetaToHpos(),
         ];
     }
 

--- a/src/Install/Migration/Versions/MigrateOrderMetaToHpos.php
+++ b/src/Install/Migration/Versions/MigrateOrderMetaToHpos.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace Buckaroo\Woocommerce\Install\Migration\Versions;
+
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use Buckaroo\Woocommerce\Install\Migration\Migration;
+use Buckaroo\Woocommerce\Services\Logger;
+use Throwable;
+use WC_Abstract_Order;
+
+/**
+ * Copies Buckaroo order meta written by older versions out of post meta onto the
+ * order, where the order API can see it under HPOS.
+ *
+ * Copies rather than moves, so a downgrade still finds its data in post meta, and
+ * never overwrites, which also makes a rerun a no-op.
+ */
+class MigrateOrderMetaToHpos implements Migration
+{
+    public $version = '4.9.1';
+
+    /** Batched through Action Scheduler; running inline on upgrade would time out. */
+    public const BATCH_HOOK = 'buckaroo_migrate_order_meta_to_hpos_batch';
+
+    public const ACTION_GROUP = 'buckaroo';
+
+    public const BATCH_SIZE = 50;
+
+    public const META_KEYS = [
+        '_wc_order_selected_payment_method',
+        '_wc_order_payment_issuer',
+        '_wc_order_authorized',
+        '_wc_order_is_captured',
+        '_wc_order_amount_captured',
+        '_wc_order_captures',
+        '_payment_method_transaction',
+        '_pushallowed',
+        '_payload_birthday',
+        '_payload_encrypted_card_data',
+        '_buckaroo_order_in_test_mode',
+        '_buckaroo_klarnakp_reservation_number',
+        '_buckaroo_klarna_data_request_key',
+        'buckaroo_settlement',
+        'buckaroo_capture',
+        'buckaroo_captures_refunded',
+        'buckaroo_is_reserved',
+    ];
+
+    /** Carry a transaction key, so they can only be matched by prefix. */
+    public const META_KEY_PREFIXES = [
+        '_capturebuckaroo',
+        '_refundbuckaroo',
+    ];
+
+    /** Hold more than one row per order, so they are compared row by row. */
+    public const MULTI_ROW_META_KEYS = [
+        '_wc_order_captures',
+        'buckaroo_capture',
+    ];
+
+    /** Kept outside the queued action so a broken chain can be resumed. */
+    public const CURSOR_OPTION = 'buckaroo_order_meta_hpos_cursor';
+
+    /** Autoloaded: read on every request that reaches the resume check. */
+    public const COMPLETE_OPTION = 'buckaroo_order_meta_hpos_complete';
+
+    /** Called on every request: a queued batch can run long after the upgrade. */
+    public static function registerBatchHandler(): void
+    {
+        add_action(self::BATCH_HOOK, [self::class, 'runBatch'], 10, 1);
+        add_action('admin_init', [self::class, 'resumeIfStalled']);
+    }
+
+    public function execute()
+    {
+        if (! self::isNeeded()) {
+            return;
+        }
+
+        update_option(self::COMPLETE_OPTION, 'no', true);
+        update_option(self::CURSOR_OPTION, 0, false);
+
+        self::scheduleBatch(0);
+    }
+
+    /** Requeue when the chain was lost: no Action Scheduler at upgrade, or a dead batch. */
+    public static function resumeIfStalled(): void
+    {
+        if (self::isComplete() || ! self::isNeeded()) {
+            return;
+        }
+
+        if (! function_exists('as_has_scheduled_action') || get_transient(self::CURSOR_OPTION . '_check')) {
+            return;
+        }
+
+        set_transient(self::CURSOR_OPTION . '_check', 1, 5 * MINUTE_IN_SECONDS);
+
+        $cursor = (int) get_option(self::CURSOR_OPTION, 0);
+
+        if (! as_has_scheduled_action(self::BATCH_HOOK, [$cursor], self::ACTION_GROUP)) {
+            self::scheduleBatch($cursor);
+        }
+    }
+
+    /**
+     * @param  int  $afterOrderId  Cursor: only orders with a higher id are considered
+     */
+    public static function runBatch($afterOrderId = 0): void
+    {
+        if (! self::isNeeded()) {
+            return;
+        }
+
+        $orderIds = self::findOrderIdsWithBuckarooPostMeta((int) $afterOrderId);
+
+        if (empty($orderIds)) {
+            update_option(self::COMPLETE_OPTION, 'yes', true);
+
+            return;
+        }
+
+        foreach ($orderIds as $orderId) {
+            try {
+                self::copyOrder($orderId);
+            } catch (Throwable $th) {
+                // One unreadable order must not strand the rest of the batch.
+                Logger::log(__METHOD__ . '|order:' . $orderId, $th);
+            }
+        }
+
+        $cursor = (int) end($orderIds);
+
+        update_option(self::CURSOR_OPTION, $cursor, false);
+
+        self::scheduleBatch($cursor);
+    }
+
+    /**
+     * Copy one order now, if the batch has not reached it yet. Without this a replayed
+     * refund push on an uncopied order reads an empty lock and refunds twice.
+     *
+     * @param  int|WC_Abstract_Order  $order
+     */
+    public static function ensureOrderMigrated($order): void
+    {
+        if (self::isComplete() || ! self::isNeeded()) {
+            return;
+        }
+
+        $orderId = $order instanceof WC_Abstract_Order ? $order->get_id() : (int) $order;
+
+        if ($orderId <= 0) {
+            return;
+        }
+
+        try {
+            self::copyOrder($orderId);
+        } catch (Throwable $th) {
+            Logger::log(__METHOD__ . '|order:' . $orderId, $th);
+        }
+    }
+
+    public static function isComplete(): bool
+    {
+        return get_option(self::COMPLETE_OPTION) === 'yes';
+    }
+
+    /**
+     * Legacy stores need nothing: the data is already where the code looks.
+     *
+     * Sync-on stores still need the copy. WooCommerce syncs on a date_updated_gmt /
+     * post_modified_gmt mismatch, and update_post_meta never touches post_modified.
+     */
+    public static function isNeeded(): bool
+    {
+        return class_exists(OrderUtil::class) && OrderUtil::custom_orders_table_usage_is_enabled();
+    }
+
+    /**
+     * @return int[] Ascending, so the cursor can advance past the batch
+     */
+    private static function findOrderIdsWithBuckarooPostMeta(int $afterOrderId): array
+    {
+        global $wpdb;
+
+        $placeholders = implode(', ', array_fill(0, count(self::META_KEYS), '%s'));
+        $conditions = ["meta_key IN ({$placeholders})"];
+        $values = self::META_KEYS;
+
+        foreach (self::META_KEY_PREFIXES as $prefix) {
+            $conditions[] = 'meta_key LIKE %s';
+            // esc_like: every prefix starts with _, which is a LIKE wildcard.
+            $values[] = $wpdb->esc_like($prefix) . '%';
+        }
+
+        $values[] = $afterOrderId;
+        $values[] = self::BATCH_SIZE;
+
+        return array_map(
+            'intval',
+            $wpdb->get_col(
+                $wpdb->prepare(
+                    "SELECT DISTINCT post_id FROM {$wpdb->postmeta}
+                     WHERE (" . implode(' OR ', $conditions) . ')
+                       AND post_id > %d
+                     ORDER BY post_id ASC
+                     LIMIT %d',
+                    $values
+                )
+            )
+        );
+    }
+
+    private static function copyOrder(int $orderId): void
+    {
+        $order = wc_get_order($orderId);
+
+        if (! $order instanceof WC_Abstract_Order) {
+            return;
+        }
+
+        $changed = false;
+
+        foreach (self::readBuckarooPostMeta($orderId) as $key => $values) {
+            if (! in_array($key, self::MULTI_ROW_META_KEYS, true)) {
+                // Never overwrite, which also makes a rerun a no-op.
+                if ($order->meta_exists($key)) {
+                    continue;
+                }
+
+                foreach ($values as $value) {
+                    $order->add_meta_data($key, $value, false);
+                }
+
+                $changed = true;
+
+                continue;
+            }
+
+            // Skipping the whole key would drop the legacy captures of an order
+            // captured again before the migration reached it, and OrderCapture bases
+            // the still-capturable amount on those rows.
+            $existing = array_map(
+                function ($meta) {
+                    return maybe_serialize($meta->value);
+                },
+                $order->get_meta($key, false)
+            );
+
+            foreach ($values as $value) {
+                $fingerprint = maybe_serialize($value);
+
+                if (in_array($fingerprint, $existing, true)) {
+                    continue;
+                }
+
+                $order->add_meta_data($key, $value, false);
+                $existing[] = $fingerprint;
+                $changed = true;
+            }
+        }
+
+        if (! $changed) {
+            return;
+        }
+
+        // A meta change on HPOS normally triggers a full $order->save(), restamping
+        // date_modified and firing woocommerce_update_order. Backfilling must not do
+        // that for every order in the shop.
+        $skipFullSave = function () {
+            return false;
+        };
+
+        add_filter('woocommerce_orders_table_datastore_should_save_after_meta_change', $skipFullSave, PHP_INT_MAX);
+
+        try {
+            $order->save_meta_data();
+        } finally {
+            remove_filter('woocommerce_orders_table_datastore_should_save_after_meta_change', $skipFullSave, PHP_INT_MAX);
+        }
+    }
+
+    /**
+     * @return array<string, array<int, mixed>> Every value per key, in insertion order
+     */
+    private static function readBuckarooPostMeta(int $orderId): array
+    {
+        global $wpdb;
+
+        $placeholders = implode(', ', array_fill(0, count(self::META_KEYS), '%s'));
+        $conditions = ["meta_key IN ({$placeholders})"];
+        $values = self::META_KEYS;
+
+        foreach (self::META_KEY_PREFIXES as $prefix) {
+            $conditions[] = 'meta_key LIKE %s';
+            $values[] = $wpdb->esc_like($prefix) . '%';
+        }
+
+        array_unshift($values, $orderId);
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT meta_key, meta_value FROM {$wpdb->postmeta}
+                 WHERE post_id = %d
+                   AND (" . implode(' OR ', $conditions) . ')
+                 ORDER BY meta_id ASC',
+                $values
+            )
+        );
+
+        $grouped = [];
+
+        foreach ($rows as $row) {
+            $grouped[$row->meta_key][] = maybe_unserialize($row->meta_value);
+        }
+
+        return $grouped;
+    }
+
+    private static function scheduleBatch(int $afterOrderId): void
+    {
+        if (! function_exists('as_enqueue_async_action')) {
+            // Skip rather than run an unbounded copy inline; resumeIfStalled retries.
+            Logger::log(__METHOD__, 'Action Scheduler is unavailable, order meta was not migrated');
+
+            return;
+        }
+
+        if (
+            function_exists('as_has_scheduled_action') &&
+            as_has_scheduled_action(self::BATCH_HOOK, [$afterOrderId], self::ACTION_GROUP)
+        ) {
+            return;
+        }
+
+        as_enqueue_async_action(self::BATCH_HOOK, [$afterOrderId], self::ACTION_GROUP);
+    }
+}

--- a/src/Order/OrderCapture.php
+++ b/src/Order/OrderCapture.php
@@ -132,7 +132,7 @@ class OrderCapture
      */
     protected function get_refunded_captures(int $order_id)
     {
-        $refunded_captures = get_post_meta($order_id, 'buckaroo_captures_refunded', true);
+        $refunded_captures = OrderMeta::get($order_id, 'buckaroo_captures_refunded');
         if (is_string($refunded_captures)) {
             $refunded_captures_decoded = json_decode($refunded_captures);
             if (is_array($refunded_captures_decoded)) {

--- a/src/Order/OrderCaptureRefund.php
+++ b/src/Order/OrderCaptureRefund.php
@@ -74,7 +74,7 @@ class OrderCaptureRefund
         $successful_refund = false;
 
         if ($capture !== null && isset($capture['transaction_id'])) {
-            $paymentMethod = get_post_meta($order_id, '_wc_order_selected_payment_method', true);
+            $paymentMethod = OrderMeta::get($order_id, '_wc_order_selected_payment_method');
             $gateway = (new PaymentGatewayRegistry())->newGatewayInstance($paymentMethod);
             $successful_refund =
                 (new RefundAction(
@@ -113,7 +113,7 @@ class OrderCaptureRefund
      */
     protected function get_capture_transaction_by_id(int $order_id, string $id)
     {
-        $captures = get_post_meta($order_id, '_wc_order_captures');
+        $captures = OrderMeta::get($order_id, '_wc_order_captures', false);
         foreach ($captures as $capture) {
             if ($capture['id'] == $id) {
                 return $capture;
@@ -185,7 +185,7 @@ class OrderCaptureRefund
         $refunded_captures = $this->get_refunded_captures($order_id);
         array_push($refunded_captures, $capture_id);
 
-        return update_post_meta(
+        return OrderMeta::update(
             $order_id,
             'buckaroo_captures_refunded',
             json_encode($refunded_captures)
@@ -200,7 +200,7 @@ class OrderCaptureRefund
      */
     protected function get_refunded_captures(int $order_id)
     {
-        $refunded_captures = get_post_meta($order_id, 'buckaroo_captures_refunded', true);
+        $refunded_captures = OrderMeta::get($order_id, 'buckaroo_captures_refunded');
         if (is_string($refunded_captures)) {
             $refunded_captures_decoded = json_decode($refunded_captures);
             if (is_array($refunded_captures_decoded)) {

--- a/src/Order/OrderDetails.php
+++ b/src/Order/OrderDetails.php
@@ -300,17 +300,17 @@ class OrderDetails
 
     public function update_meta(string $key, $value)
     {
-        return update_post_meta($this->order->get_id(), $key, $value);
+        return OrderMeta::update($this->order, $key, $value);
     }
 
     public function add_meta(string $key, $value, $unique = false)
     {
-        return add_post_meta($this->order->get_id(), $key, $value, $unique);
+        return OrderMeta::add($this->order, $key, $value, (bool) $unique);
     }
 
     public function get_meta(string $key, $single = false)
     {
-        return get_post_meta($this->order->get_id(), $key, $single);
+        return OrderMeta::get($this->order, $key, (bool) $single);
     }
 
     /**

--- a/src/Order/OrderMeta.php
+++ b/src/Order/OrderMeta.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Buckaroo\Woocommerce\Order;
+
+use WC_Abstract_Order;
+use WC_Meta_Data;
+
+/**
+ * Order meta accessor.
+ *
+ * Under HPOS the *_post_meta functions read and write the `shop_order_placehold` post
+ * row instead of the order, so the data is invisible to the order APIs. Everything
+ * here goes through the WooCommerce order meta API and falls back to post meta when
+ * the argument is not an order. The fallback is permanent: non-HPOS stores need it.
+ */
+class OrderMeta
+{
+    /**
+     * @param  int|WC_Abstract_Order  $order
+     * @return mixed
+     */
+    public static function get($order, string $key, bool $single = true)
+    {
+        $resolved = self::resolve($order);
+
+        if ($resolved === null) {
+            return get_post_meta(self::fallbackId($order), $key, $single);
+        }
+
+        // 'edit' skips the woocommerce_order_get_<key> filter. get_post_meta had no
+        // per-key filter, and these values decide whether a payment is captured.
+        if ($single) {
+            return $resolved->get_meta($key, true, 'edit');
+        }
+
+        // get_post_meta returns meta_id order; the HPOS meta query has no ORDER BY.
+        // AbstractRefundProcessor picks its transaction key with end($captures).
+        // Position is the tie breaker, because usort is not stable on PHP 7.4.
+        $ordered = [];
+        $position = 0;
+
+        foreach ($resolved->get_meta($key, false, 'edit') as $meta) {
+            $ordered[] = [self::metaSortKey($meta), $position++, $meta];
+        }
+
+        usort(
+            $ordered,
+            function ($a, $b) {
+                return [$a[0], $a[1]] <=> [$b[0], $b[1]];
+            }
+        );
+
+        return array_map(
+            function ($row) {
+                return $row[2] instanceof WC_Meta_Data ? $row[2]->value : $row[2];
+            },
+            $ordered
+        );
+    }
+
+    /**
+     * Unsaved meta has no id and is the newest, so it sorts last.
+     *
+     * @param  WC_Meta_Data|mixed  $meta
+     */
+    private static function metaSortKey($meta): int
+    {
+        if (! $meta instanceof WC_Meta_Data || empty($meta->id)) {
+            return PHP_INT_MAX;
+        }
+
+        return (int) $meta->id;
+    }
+
+    /**
+     * @param  int|WC_Abstract_Order  $order
+     * @param  mixed  $value
+     */
+    public static function update($order, string $key, $value): bool
+    {
+        $resolved = self::resolve($order);
+
+        if ($resolved === null) {
+            return (bool) update_post_meta(self::fallbackId($order), $key, $value);
+        }
+
+        $resolved->update_meta_data($key, $value);
+        $resolved->save_meta_data();
+
+        return true;
+    }
+
+    /**
+     * @param  int|WC_Abstract_Order  $order
+     * @param  mixed  $value
+     * @param  bool  $unique  Write nothing and return false when the key exists,
+     *                        which add_meta_data does not do on its own
+     */
+    public static function add($order, string $key, $value, bool $unique = false): bool
+    {
+        $resolved = self::resolve($order);
+
+        if ($resolved === null) {
+            return (bool) add_post_meta(self::fallbackId($order), $key, $value, $unique);
+        }
+
+        if ($unique && $resolved->meta_exists($key)) {
+            return false;
+        }
+
+        $resolved->add_meta_data($key, $value, $unique);
+        $resolved->save_meta_data();
+
+        return true;
+    }
+
+    /**
+     * @param  int|WC_Abstract_Order  $order
+     */
+    public static function delete($order, string $key): bool
+    {
+        $resolved = self::resolve($order);
+
+        if ($resolved === null) {
+            return (bool) delete_post_meta(self::fallbackId($order), $key);
+        }
+
+        $resolved->delete_meta_data($key);
+        $resolved->save_meta_data();
+
+        return true;
+    }
+
+    /**
+     * @param  int|WC_Abstract_Order  $order
+     * @return WC_Abstract_Order|null
+     */
+    protected static function resolve($order)
+    {
+        if ($order instanceof WC_Abstract_Order) {
+            return $order;
+        }
+
+        // A non-positive id would make wc_get_order() fall back to the global $post.
+        if (! function_exists('wc_get_order') || ! is_numeric($order) || (int) $order <= 0) {
+            return null;
+        }
+
+        $resolved = wc_get_order((int) $order);
+
+        return $resolved instanceof WC_Abstract_Order ? $resolved : null;
+    }
+
+    /**
+     * @param  int|WC_Abstract_Order  $order
+     */
+    protected static function fallbackId($order): int
+    {
+        if ($order instanceof WC_Abstract_Order) {
+            return $order->get_id();
+        }
+
+        return is_numeric($order) ? (int) $order : 0;
+    }
+}

--- a/src/PaymentProcessors/Actions/CaptureAction.php
+++ b/src/PaymentProcessors/Actions/CaptureAction.php
@@ -2,6 +2,7 @@
 
 namespace Buckaroo\Woocommerce\PaymentProcessors\Actions;
 
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\Services\Logger;
 use BuckarooDeps\Buckaroo\Transaction\Response\TransactionResponse;
 use WP_Error;
@@ -18,17 +19,17 @@ class CaptureAction
         if ($response && $response->isSuccess()) {
             // SET the flags
             // check if order has already been captured
-            if (get_post_meta($order->get_id(), '_wc_order_is_captured', true)) {
+            if (OrderMeta::get($order, '_wc_order_is_captured')) {
                 // Order already captured
                 // Add the other values of the capture so we have the full value captured
-                $previousCaptures = (float) get_post_meta($order->get_id(), '_wc_order_amount_captured', true);
+                $previousCaptures = (float) OrderMeta::get($order, '_wc_order_amount_captured');
                 $total = $previousCaptures + (float) $capture_amount;
-                update_post_meta($order->get_id(), '_wc_order_amount_captured', $total);
+                OrderMeta::update($order, '_wc_order_amount_captured', $total);
             } else {
                 // Order not captured yet
                 // Set first amout_captured and is_captured flag
-                update_post_meta($order->get_id(), '_wc_order_is_captured', true);
-                update_post_meta($order->get_id(), '_wc_order_amount_captured', $capture_amount);
+                OrderMeta::update($order, '_wc_order_is_captured', true);
+                OrderMeta::update($order, '_wc_order_amount_captured', $capture_amount);
             }
 
             $str = '';
@@ -40,8 +41,8 @@ class CaptureAction
             }
 
             // Set the flag that contains all the items and taxes that have been captured
-            add_post_meta(
-                $order->get_id(),
+            OrderMeta::add(
+                $order,
                 '_wc_order_captures',
                 [
                     'currency' => $currency,
@@ -54,8 +55,8 @@ class CaptureAction
                 ]
             );
 
-            add_post_meta($order->get_id(), '_capturebuckaroo' . $response->getTransactionKey(), 'ok', true);
-            update_post_meta($order->get_id(), '_pushallowed', 'ok');
+            OrderMeta::add($order, '_capturebuckaroo' . $response->getTransactionKey(), 'ok', true);
+            OrderMeta::update($order, '_pushallowed', 'ok');
 
             $order->add_order_note(
                 sprintf(
@@ -73,7 +74,7 @@ class CaptureAction
                         'products' => $products,
                     ]
                 );
-                add_post_meta($order->get_id(), 'buckaroo_capture', $capture_data, false);
+                OrderMeta::add($order, 'buckaroo_capture', $capture_data, false);
             }
             wp_send_json_success($response->toArray());
         }
@@ -88,7 +89,7 @@ class CaptureAction
                     $order->get_transaction_id()
                 )
             );
-            update_post_meta($order->get_id(), '_pushallowed', 'ok');
+            OrderMeta::update($order, '_pushallowed', 'ok');
 
             return new WP_Error('error_capture', __('Capture failed: ') . $response->getSomeError());
         } else {
@@ -98,7 +99,7 @@ class CaptureAction
                     $order->get_transaction_id()
                 )
             );
-            update_post_meta($order->get_id(), '_pushallowed', 'ok');
+            OrderMeta::update($order, '_pushallowed', 'ok');
 
             return false;
         }

--- a/src/PaymentProcessors/Actions/RefundAction.php
+++ b/src/PaymentProcessors/Actions/RefundAction.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\PaymentProcessors\Actions;
 
 use Buckaroo\Woocommerce\Gateways\AbstractRefundProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
 use Buckaroo\Woocommerce\Services\BuckarooClient;
 use Buckaroo\Woocommerce\Services\Logger;
@@ -32,12 +33,12 @@ class RefundAction
     public static function initiateExternalServiceRefund($order_id, ResponseParser $responseParser)
     {
         Logger::log('PUSH', 'Refund payment PUSH received ' . $responseParser->get('coreStatus'));
-        $allowedPush = get_post_meta($order_id, '_pushallowed', true);
+        $allowedPush = OrderMeta::get($order_id, '_pushallowed');
         Logger::log(__METHOD__ . '|10|', $allowedPush);
         if ($responseParser->isSuccess() && $allowedPush == 'ok') {
-            $tmp = get_post_meta($order_id, '_refundbuckaroo' . $responseParser->getTransactionKey(), true);
+            $tmp = OrderMeta::get($order_id, '_refundbuckaroo' . $responseParser->getTransactionKey());
             if (empty($tmp)) {
-                add_post_meta($order_id, '_refundbuckaroo' . $responseParser->getTransactionKey(), 'ok', true);
+                OrderMeta::add($order_id, '_refundbuckaroo' . $responseParser->getTransactionKey(), 'ok', true);
                 wc_create_refund(
                     [
                         'amount' => $responseParser->getAmountCredit(),
@@ -71,8 +72,8 @@ class RefundAction
                     $transactionResponse->getTransactionKey()
                 )
             );
-            add_post_meta(
-                $this->order->get_id(),
+            OrderMeta::add(
+                $this->order,
                 '_refundbuckaroo' . $transactionResponse->getTransactionKey(),
                 'ok',
                 true
@@ -89,8 +90,8 @@ class RefundAction
                     $transactionResponse->getTransactionKey()
                 )
             );
-            add_post_meta(
-                $this->order->get_id(),
+            OrderMeta::add(
+                $this->order,
                 '_refundbuckaroo' . $transactionResponse->getTransactionKey(),
                 'ok',
                 true

--- a/src/PaymentProcessors/PushProcessor.php
+++ b/src/PaymentProcessors/PushProcessor.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Woocommerce\PaymentProcessors;
 use Buckaroo\Woocommerce\Constraints\BuckarooTransactionStatus;
 use Buckaroo\Woocommerce\Gateways\Klarna\KlarnaProcessor;
 use Buckaroo\Woocommerce\Gateways\PaypalExpress\PaypalExpressUpdateOrderAddresses;
+use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateOrderMetaToHpos;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\RefundAction;
 use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
 use Buckaroo\Woocommerce\ResponseParser\ResponseRegistry;
@@ -121,7 +123,7 @@ class PushProcessor
 
                     $orderAmount = Helper::roundAmount($order->get_total());
                     $paidAmount = Helper::roundAmount($responseParser->getAmount());
-                    $settlementState = $this->calculateSettlementState($order_id, $responseParser, $paidAmount);
+                    $settlementState = $this->calculateSettlementState($order, $responseParser, $paidAmount);
                     $totalPaid = $settlementState['totalPaid'];
                     $isNewPayment = $settlementState['isNewPayment'];
 
@@ -140,9 +142,9 @@ class PushProcessor
                         $order->add_order_note($message);
                     }
 
-                    add_post_meta($order_id, '_payment_method_transaction', $payment_methodname, true);
-                    $this->updateSettlementMeta($order_id, $responseParser, $paidAmount);
-                    add_post_meta($order_id, '_pushallowed', 'ok', true);
+                    OrderMeta::add($order, '_payment_method_transaction', $payment_methodname, true);
+                    $this->updateSettlementMeta($order, $responseParser, $paidAmount);
+                    OrderMeta::add($order, '_pushallowed', 'ok', true);
 
                     break;
                 default:
@@ -180,10 +182,10 @@ class PushProcessor
         return ! empty($transactions) ? explode(',', $transactions) : '';
     }
 
-    protected function calculateSettlementState($order_id, ResponseParser $responseParser, $paidAmount)
+    protected function calculateSettlementState($order, ResponseParser $responseParser, $paidAmount)
     {
         $currentKey = $this->getTransactionKey($responseParser);
-        $settlements = get_post_meta($order_id, 'buckaroo_settlement', true);
+        $settlements = OrderMeta::get($order, 'buckaroo_settlement');
         if (!is_array($settlements)) {
             $settlements = [];
         }
@@ -197,17 +199,17 @@ class PushProcessor
         ];
     }
 
-    protected function updateSettlementMeta($order_id, ResponseParser $responseParser, $paidAmount)
+    protected function updateSettlementMeta($order, ResponseParser $responseParser, $paidAmount)
     {
         $currentKey = $this->getTransactionKey($responseParser);
-        $settlements = get_post_meta($order_id, 'buckaroo_settlement', true);
+        $settlements = OrderMeta::get($order, 'buckaroo_settlement');
         if (!is_array($settlements)) {
             $settlements = [];
         }
 
         $settlements[$currentKey] = (float) $paidAmount;
 
-        update_post_meta($order_id, 'buckaroo_settlement', $settlements);
+        OrderMeta::update($order, 'buckaroo_settlement', $settlements);
     }
 
     protected function isOrderFullyPaid($order)
@@ -311,6 +313,9 @@ class PushProcessor
                 exit();
             }
 
+            // Locks below are read from order meta; copy first so a replay is seen.
+            MigrateOrderMetaToHpos::ensureOrderMigrated($order);
+
             if ($responseParser->getRefundParentKey() !== null) {
                 RefundAction::initiateExternalServiceRefund($order_id, $responseParser);
             }
@@ -346,7 +351,7 @@ class PushProcessor
                         )
                     );
                 }
-                add_post_meta($order_id, '_pushallowed', 'ok', true);
+                OrderMeta::add($order, '_pushallowed', 'ok', true);
 
                 return;
             }

--- a/src/PaymentProcessors/ReturnProcessor.php
+++ b/src/PaymentProcessors/ReturnProcessor.php
@@ -3,6 +3,7 @@
 namespace Buckaroo\Woocommerce\PaymentProcessors;
 
 use Buckaroo\Woocommerce\Gateways\AbstractPaymentGateway;
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
 use Buckaroo\Woocommerce\ResponseParser\ResponseRegistry;
 use Buckaroo\Woocommerce\Services\BuckarooClient;
@@ -61,7 +62,7 @@ class ReturnProcessor
         $order->set_transaction_id($responseParser->getTransactionKey());
         $order->save();
 
-        update_post_meta($orderId, '_buckaroo_order_in_test_mode', $responseParser->isTest());
+        OrderMeta::update($order, '_buckaroo_order_in_test_mode', $responseParser->isTest());
 
         // Check if we need to redirect first (based on the response)
         if ($redirect = Helper::processCheckRedirectRequired($responseParser)) {

--- a/src/Services/Helper.php
+++ b/src/Services/Helper.php
@@ -86,13 +86,20 @@ class Helper
         if ($order_id) {
             $order = wc_get_order($order_id);
 
-            $status = get_post_status($order_id);
+            if (! self::isOrderInstance($order)) {
+                return;
+            }
 
-            if (($status == 'wc-failed' || $status == 'wc-cancelled') && wc_notice_count('error') == 0) {
-                // Add generated hash to order for WooCommerce versions later than 2.5
-                if (version_compare(WC()->version, '2.5', '>')) {
-                    $order->cart_hash = md5(json_encode(wc_clean(WC()->cart->get_cart_for_session())) . WC()->cart->total);
-                }
+            // get_post_status() returns the placeholder post's "draft" under HPOS, so
+            // this branch never ran there. get_status() is unprefixed.
+            $status = $order->get_status();
+
+            if (($status == 'failed' || $status == 'cancelled') && wc_notice_count('error') == 0) {
+                // $order->cart_hash only set a dynamic property, so it never reached
+                // the order (and is deprecated as of PHP 8.2).
+                $order->set_cart_hash(
+                    md5(json_encode(wc_clean(WC()->cart->get_cart_for_session())) . WC()->cart->total)
+                );
 
                 if (version_compare(WC()->version, '3.6', '>=')) {
                     Logger::log('Update status 7. Order status: cancelled');

--- a/tests/Support/HposStorage.php
+++ b/tests/Support/HposStorage.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+/**
+ * Switches the test store between HPOS and the legacy post storage.
+ */
+trait HposStorage
+{
+    /** @var int[] */
+    private $createdOrderIds = [];
+
+    /** @var bool */
+    private static $purgedOrphanedRows = false;
+
+    /** HPOS on with posts sync off: where post meta and order meta diverge. */
+    protected function enableHpos(): void
+    {
+        $this->allowStorageSwitch();
+        update_option('woocommerce_custom_orders_table_data_sync_enabled', 'no');
+        update_option('woocommerce_custom_orders_table_enabled', 'yes');
+
+        if (! OrderUtil::custom_orders_table_usage_is_enabled()) {
+            $this->markTestSkipped('Could not enable HPOS in the test environment');
+        }
+
+        $this->purgeOrphanedOrderRows();
+    }
+
+    /**
+     * The bootstrap resets wp_posts between runs but not the order tables, so order
+     * ids restart and can collide with a previous run's rows.
+     */
+    private function purgeOrphanedOrderRows(): void
+    {
+        if (self::$purgedOrphanedRows) {
+            return;
+        }
+
+        self::$purgedOrphanedRows = true;
+
+        global $wpdb;
+
+        // Raw deletes: only ever run against the test suite's own database.
+        if (! defined('WP_TESTS_DOMAIN') || strpos($wpdb->prefix, 'wptests_') !== 0) {
+            return;
+        }
+
+        foreach (['wc_orders' => 'id', 'wc_orders_meta' => 'order_id', 'wc_order_addresses' => 'order_id', 'wc_order_operational_data' => 'order_id'] as $table => $column) {
+            $wpdb->query(
+                "DELETE FROM {$wpdb->prefix}{$table}
+                 WHERE {$column} NOT IN (SELECT ID FROM {$wpdb->posts})"
+            );
+        }
+    }
+
+    /** Restore legacy storage, so later tests are unaffected. */
+    protected function disableHpos(): void
+    {
+        $this->allowStorageSwitch();
+        update_option('woocommerce_custom_orders_table_enabled', 'no');
+    }
+
+    private function allowStorageSwitch(): void
+    {
+        add_filter('wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true');
+    }
+
+    /** A saved order with no meta of its own, in whichever storage is authoritative. */
+    protected function createOrder(): WC_Order
+    {
+        $order = new WC_Order();
+        $order->set_status('pending');
+        $order->save();
+
+        $this->createdOrderIds[] = $order->get_id();
+
+        $stale = wc_get_order($order->get_id());
+
+        if (! $stale instanceof WC_Order) {
+            $this->fail(sprintf(
+                'Order %d could not be read back after being saved. The order tables and wp_posts are probably out of step - check for leftover rows from an earlier run.',
+                $order->get_id()
+            ));
+        }
+
+        foreach ($stale->get_meta_data() as $meta) {
+            $stale->delete_meta_data($meta->key);
+        }
+        $stale->save_meta_data();
+
+        return wc_get_order($order->get_id());
+    }
+
+    /** Remove this test's orders, so they are not carried into the next run. */
+    protected function deleteCreatedOrders(): void
+    {
+        foreach ($this->createdOrderIds as $orderId) {
+            $order = wc_get_order($orderId);
+
+            if ($order instanceof WC_Order) {
+                $order->delete(true);
+            }
+        }
+
+        $this->createdOrderIds = [];
+    }
+}

--- a/tests/Test_Helper.php
+++ b/tests/Test_Helper.php
@@ -11,6 +11,16 @@ use PHPUnit\Framework\TestCase;
  */
 class Test_Helper extends TestCase
 {
+    use HposStorage;
+
+    protected function tearDown(): void
+    {
+        WC()->session->order_awaiting_payment = null;
+        $this->deleteCreatedOrders();
+        $this->disableHpos();
+        parent::tearDown();
+    }
+
     /**
      * Test handleUnsuccessfulPayment method with cancelled status
      */
@@ -223,5 +233,73 @@ class Test_Helper extends TestCase
         // This will return false if the provider is invalid
         $result = Helper::checkCreditCardProvider('invalid_provider');
         $this->assertFalse($result);
+    }
+
+    /**
+     * resetOrder used to read the status with get_post_status(), which returns
+     * "draft" for the shop_order_placehold row under HPOS, so the branch never ran.
+     */
+    public function test_reset_order_cancels_a_failed_order_on_an_hpos_store()
+    {
+        $this->enableHpos();
+
+        $order = $this->createOrder();
+        $order->set_status('failed');
+        $order->save();
+
+        WC()->session->order_awaiting_payment = $order->get_id();
+
+        Helper::resetOrder();
+
+        $cancelled = wc_get_order($order->get_id());
+        $this->assertSame('cancelled', $cancelled->get_status());
+        $this->assertNotSame('', $cancelled->get_cart_hash(), 'The cart hash should have been rebuilt');
+    }
+
+    public function test_reset_order_leaves_an_order_in_any_other_status_alone()
+    {
+        $this->enableHpos();
+
+        foreach (['pending', 'on-hold', 'processing', 'completed'] as $status) {
+            $order = $this->createOrder();
+            $order->set_status($status);
+            $order->save();
+
+            WC()->session->order_awaiting_payment = $order->get_id();
+
+            Helper::resetOrder();
+
+            $this->assertSame(
+                $status,
+                wc_get_order($order->get_id())->get_status(),
+                "Order in status {$status} should not have been touched"
+            );
+        }
+    }
+
+    public function test_reset_order_cancels_an_already_cancelled_order()
+    {
+        $this->enableHpos();
+
+        $order = $this->createOrder();
+        $order->set_status('cancelled');
+        $order->save();
+
+        WC()->session->order_awaiting_payment = $order->get_id();
+
+        Helper::resetOrder();
+
+        $this->assertSame('cancelled', wc_get_order($order->get_id())->get_status());
+    }
+
+    public function test_reset_order_handles_a_session_order_that_no_longer_exists()
+    {
+        $this->enableHpos();
+
+        WC()->session->order_awaiting_payment = 999999999;
+
+        Helper::resetOrder();
+
+        $this->assertFalse(wc_get_order(999999999));
     }
 }

--- a/tests/Test_KlarnaOrderMeta.php
+++ b/tests/Test_KlarnaOrderMeta.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Buckaroo\Woocommerce\Gateways\Klarna\KlarnaCancelReservation;
+use Buckaroo\Woocommerce\Gateways\Klarna\KlarnaProcessor;
+use Buckaroo\Woocommerce\Order\OrderMeta;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The reservation number and data request key tie an order to a Klarna reservation;
+ * capture, refund and cancel all resolve it through them.
+ */
+class Test_KlarnaOrderMeta extends TestCase
+{
+    use HposStorage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists('WC_Order')) {
+            $this->markTestSkipped('WooCommerce is not available');
+        }
+
+        $this->enableHpos();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteCreatedOrders();
+        $this->disableHpos();
+        parent::tearDown();
+    }
+
+    public function test_klarnakp_reservation_number_round_trips_on_an_hpos_store()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::update($order, '_buckaroo_klarnakp_reservation_number', '1234567890');
+
+        $this->assertSame(
+            '1234567890',
+            OrderMeta::get($order->get_id(), '_buckaroo_klarnakp_reservation_number')
+        );
+        $this->assertSame(
+            '',
+            get_post_meta($order->get_id(), '_buckaroo_klarnakp_reservation_number', true),
+            'The reservation number should no longer be written to post meta'
+        );
+    }
+
+    public function test_klarna_data_request_key_round_trips_on_an_hpos_store()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::update($order, KlarnaProcessor::DATA_REQUEST_META_KEY, 'DATAREQUESTKEY123');
+
+        $this->assertSame(
+            'DATAREQUESTKEY123',
+            OrderMeta::get($order->get_id(), KlarnaProcessor::DATA_REQUEST_META_KEY)
+        );
+    }
+
+    public function test_a_missing_reservation_number_reads_back_as_an_empty_string()
+    {
+        $order = $this->createOrder();
+
+        $reservationNumber = OrderMeta::get($order->get_id(), '_buckaroo_klarnakp_reservation_number');
+
+        $this->assertSame('', $reservationNumber);
+        $this->assertFalse(is_string($reservationNumber) && strlen($reservationNumber) > 0);
+    }
+
+    public function test_cancel_reservation_action_is_offered_for_a_reserved_klarnakp_order()
+    {
+        $order = $this->createOrder();
+        $order->set_payment_method('buckaroo_klarnakp');
+        $order->save();
+
+        OrderMeta::update($order, 'buckaroo_is_reserved', 'yes');
+
+        $actions = (new KlarnaCancelReservation())->add_cancel_option([], wc_get_order($order->get_id()));
+
+        $this->assertArrayHasKey('buckaroo_klarnakp_cancel_reservation', $actions);
+    }
+
+    public function test_cancel_reservation_action_is_not_offered_when_nothing_is_reserved()
+    {
+        $order = $this->createOrder();
+        $order->set_payment_method('buckaroo_klarnakp');
+        $order->save();
+
+        $actions = (new KlarnaCancelReservation())->add_cancel_option([], wc_get_order($order->get_id()));
+
+        $this->assertArrayNotHasKey('buckaroo_klarnakp_cancel_reservation', $actions);
+    }
+
+    public function test_cancel_reservation_action_is_not_offered_for_another_payment_method()
+    {
+        $order = $this->createOrder();
+        $order->set_payment_method('buckaroo_ideal');
+        $order->save();
+
+        OrderMeta::update($order, 'buckaroo_is_reserved', 'yes');
+
+        $actions = (new KlarnaCancelReservation())->add_cancel_option([], wc_get_order($order->get_id()));
+
+        $this->assertArrayNotHasKey('buckaroo_klarnakp_cancel_reservation', $actions);
+    }
+}

--- a/tests/Test_MigrateOrderMetaToHpos.php
+++ b/tests/Test_MigrateOrderMetaToHpos.php
@@ -1,0 +1,584 @@
+<?php
+
+declare(strict_types=1);
+
+use Buckaroo\Woocommerce\Core\Plugin;
+use Buckaroo\Woocommerce\Install\Migration\Migration;
+use Buckaroo\Woocommerce\Install\Migration\MigrationHandler;
+use Buckaroo\Woocommerce\Install\Migration\Versions\MigrateOrderMetaToHpos;
+use Buckaroo\Woocommerce\Order\OrderMeta;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Older orders keep their Buckaroo data in post meta once HPOS is authoritative.
+ */
+class Test_MigrateOrderMetaToHpos extends TestCase
+{
+    use HposStorage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists('WC_Order')) {
+            $this->markTestSkipped('WooCommerce is not available');
+        }
+
+        $this->enableHpos();
+    }
+
+    protected function tearDown(): void
+    {
+        if (function_exists('as_unschedule_all_actions')) {
+            as_unschedule_all_actions(MigrateOrderMetaToHpos::BATCH_HOOK);
+        }
+
+        delete_option(MigrateOrderMetaToHpos::CURSOR_OPTION);
+        delete_option(MigrateOrderMetaToHpos::COMPLETE_OPTION);
+        delete_transient(MigrateOrderMetaToHpos::CURSOR_OPTION . '_check');
+
+        $this->deleteCreatedOrders();
+        $this->disableHpos();
+        parent::tearDown();
+    }
+
+    /**
+     * A push after the upgrade writes _pushallowed to order meta while
+     * _refundbuckaroo<key> is still in post meta, so a replay would refund again.
+     */
+    public function test_a_replayed_refund_cannot_slip_through_before_the_batch_copy_arrives()
+    {
+        $order = $this->createOrder();
+        $transactionKey = 'LEGACY_TX';
+
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+        update_post_meta($order->get_id(), '_refundbuckaroo' . $transactionKey, 'ok');
+
+        // A push lands before the batch copy reaches this order.
+        OrderMeta::add($order, '_pushallowed', 'ok', true);
+
+        $this->assertSame(
+            '',
+            OrderMeta::get($order->get_id(), '_refundbuckaroo' . $transactionKey),
+            'This is the dangerous state the fix has to remove'
+        );
+
+        MigrateOrderMetaToHpos::ensureOrderMigrated($order->get_id());
+
+        $this->assertSame(
+            'ok',
+            OrderMeta::get($order->get_id(), '_refundbuckaroo' . $transactionKey),
+            'The refund lock has to be readable, or the replay refunds a second time'
+        );
+    }
+
+    public function test_ensure_order_migrated_costs_nothing_once_the_copy_is_finished()
+    {
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+
+        update_option(MigrateOrderMetaToHpos::COMPLETE_OPTION, 'yes', false);
+
+        MigrateOrderMetaToHpos::ensureOrderMigrated($order->get_id());
+
+        $this->assertSame('', OrderMeta::get($order->get_id(), '_pushallowed'));
+    }
+
+    public function test_an_empty_batch_marks_the_copy_complete()
+    {
+        $order = $this->createOrder();
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id());
+
+        $this->assertTrue(MigrateOrderMetaToHpos::isComplete());
+    }
+
+    /**
+     * upgrader_process_complete only fires for updates through the WordPress updater,
+     * so a git or rsync deploy never sets the transient and execute() never runs.
+     */
+    public function test_the_copy_still_happens_when_the_upgrade_hook_never_fired()
+    {
+        if (! function_exists('as_has_scheduled_action')) {
+            $this->markTestSkipped('Action Scheduler is not available');
+        }
+
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+
+        // Exactly the state after a file-copy deploy: execute() was never called, so
+        // neither option exists.
+        delete_option(MigrateOrderMetaToHpos::COMPLETE_OPTION);
+        delete_option(MigrateOrderMetaToHpos::CURSOR_OPTION);
+        delete_transient(MigrateOrderMetaToHpos::CURSOR_OPTION . '_check');
+        as_unschedule_all_actions(MigrateOrderMetaToHpos::BATCH_HOOK);
+
+        MigrateOrderMetaToHpos::resumeIfStalled();
+
+        $this->assertTrue(
+            as_has_scheduled_action(MigrateOrderMetaToHpos::BATCH_HOOK, [0], MigrateOrderMetaToHpos::ACTION_GROUP),
+            'admin_init has to queue the copy even though the upgrade hook never fired'
+        );
+
+        MigrateOrderMetaToHpos::runBatch(0);
+
+        $this->assertSame('ok', OrderMeta::get($order->get_id(), '_pushallowed'));
+    }
+
+    public function test_a_stalled_chain_is_requeued_from_the_stored_cursor()
+    {
+        if (! function_exists('as_has_scheduled_action')) {
+            $this->markTestSkipped('Action Scheduler is not available');
+        }
+
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+
+        // A batch ran and stored its cursor, then the queue was lost.
+        update_option(MigrateOrderMetaToHpos::COMPLETE_OPTION, 'no', false);
+        update_option(MigrateOrderMetaToHpos::CURSOR_OPTION, $order->get_id() - 1, false);
+        as_unschedule_all_actions(MigrateOrderMetaToHpos::BATCH_HOOK);
+
+        MigrateOrderMetaToHpos::resumeIfStalled();
+
+        $this->assertTrue(
+            as_has_scheduled_action(
+                MigrateOrderMetaToHpos::BATCH_HOOK,
+                [$order->get_id() - 1],
+                MigrateOrderMetaToHpos::ACTION_GROUP
+            ),
+            'A lost chain has to be picked back up from the stored cursor'
+        );
+    }
+
+    public function test_migration_is_registered_at_version_4_9_1()
+    {
+        $migration = new MigrateOrderMetaToHpos();
+
+        $this->assertInstanceOf(Migration::class, $migration);
+        $this->assertSame('4.9.1', $migration->version);
+    }
+
+    /**
+     * MigrationHandler keeps only version <= Plugin::VERSION and > the database
+     * version. Get either wrong and the copy silently never runs.
+     */
+    public function test_migration_handler_actually_selects_this_migration()
+    {
+        $version = (new MigrateOrderMetaToHpos())->version;
+
+        $this->assertTrue(
+            version_compare($version, Plugin::VERSION, '<='),
+            sprintf(
+                'Migration version %s is above Plugin::VERSION %s, so MigrationHandler would filter it out and it would never run.',
+                $version,
+                Plugin::VERSION
+            )
+        );
+
+        $this->assertTrue(
+            version_compare($version, '4.9.0', '>'),
+            'Migration version has to be above the previous release, or stores already on it would skip the copy.'
+        );
+
+        $handler = new MigrationHandler();
+        $method = new \ReflectionMethod(MigrationHandler::class, 'get_migration_items');
+        $method->setAccessible(true);
+
+        $registered = array_map('get_class', $method->invoke($handler));
+
+        $this->assertContains(MigrateOrderMetaToHpos::class, $registered);
+    }
+
+    public function test_it_copies_a_static_key_from_post_meta_to_order_meta()
+    {
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_wc_order_selected_payment_method', 'KlarnaPay');
+
+        $this->assertSame(
+            '',
+            OrderMeta::get($order->get_id(), '_wc_order_selected_payment_method'),
+            'The value should be invisible to the order API before the migration'
+        );
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->assertSame(
+            'KlarnaPay',
+            OrderMeta::get($order->get_id(), '_wc_order_selected_payment_method')
+        );
+    }
+
+    public function test_it_leaves_the_post_meta_rows_in_place()
+    {
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->assertSame(
+            'ok',
+            get_post_meta($order->get_id(), '_pushallowed', true),
+            'A downgrade to an older plugin has to still find its data in post meta'
+        );
+    }
+
+    public function test_it_copies_every_row_of_a_multi_row_key()
+    {
+        $order = $this->createOrder();
+        add_post_meta($order->get_id(), '_wc_order_captures', ['id' => 'a', 'amount' => '1.00']);
+        add_post_meta($order->get_id(), '_wc_order_captures', ['id' => 'b', 'amount' => '2.00']);
+        add_post_meta($order->get_id(), 'buckaroo_capture', 'first');
+        add_post_meta($order->get_id(), 'buckaroo_capture', 'second');
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->assertSame(
+            [
+                ['id' => 'a', 'amount' => '1.00'],
+                ['id' => 'b', 'amount' => '2.00'],
+            ],
+            OrderMeta::get($order->get_id(), '_wc_order_captures', false)
+        );
+        $this->assertSame(
+            ['first', 'second'],
+            OrderMeta::get($order->get_id(), 'buckaroo_capture', false)
+        );
+    }
+
+    public function test_it_copies_an_array_value_back_as_an_array()
+    {
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), 'buckaroo_settlement', ['TX_ONE' => 20.00]);
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->assertSame(
+            ['TX_ONE' => 20.00],
+            OrderMeta::get($order->get_id(), 'buckaroo_settlement')
+        );
+    }
+
+    /** Prefix starts with an underscore, which is a LIKE wildcard. */
+    public function test_it_copies_the_dynamic_capture_and_refund_locks_by_prefix()
+    {
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_capturebuckarooTXKEY111', 'ok');
+        update_post_meta($order->get_id(), '_refundbuckarooTXKEY222', 'ok');
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->assertSame('ok', OrderMeta::get($order->get_id(), '_capturebuckarooTXKEY111'));
+        $this->assertSame('ok', OrderMeta::get($order->get_id(), '_refundbuckarooTXKEY222'));
+    }
+
+    public function test_running_it_twice_produces_no_duplicates()
+    {
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+        add_post_meta($order->get_id(), 'buckaroo_capture', 'first');
+        add_post_meta($order->get_id(), 'buckaroo_capture', 'second');
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->assertSame(['ok'], OrderMeta::get($order->get_id(), '_pushallowed', false));
+        $this->assertSame(['first', 'second'], OrderMeta::get($order->get_id(), 'buckaroo_capture', false));
+    }
+
+    /**
+     * A capture after the upgrade puts one row on the order while the legacy rows are
+     * still in post meta. Losing those would allow an over-capture.
+     */
+    public function test_it_copies_legacy_capture_rows_even_when_the_order_already_has_one()
+    {
+        $order = $this->createOrder();
+
+        add_post_meta($order->get_id(), '_wc_order_captures', ['id' => 'legacy-1', 'amount' => '10.00']);
+        add_post_meta($order->get_id(), '_wc_order_captures', ['id' => 'legacy-2', 'amount' => '20.00']);
+
+        // A capture taken after the upgrade, written by the new code onto the order.
+        OrderMeta::add($order, '_wc_order_captures', ['id' => 'post-upgrade', 'amount' => '5.00']);
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $captures = OrderMeta::get($order->get_id(), '_wc_order_captures', false);
+
+        $this->assertSame(
+            ['post-upgrade', 'legacy-1', 'legacy-2'],
+            array_column($captures, 'id'),
+            'The legacy capture rows have to survive alongside the newer one'
+        );
+    }
+
+    public function test_multi_row_keys_are_not_duplicated_when_the_migration_reruns()
+    {
+        $order = $this->createOrder();
+
+        add_post_meta($order->get_id(), '_wc_order_captures', ['id' => 'legacy-1', 'amount' => '10.00']);
+        add_post_meta($order->get_id(), 'buckaroo_capture', 'payload-one');
+        add_post_meta($order->get_id(), 'buckaroo_capture', 'payload-two');
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->assertSame(
+            ['legacy-1'],
+            array_column(OrderMeta::get($order->get_id(), '_wc_order_captures', false), 'id')
+        );
+        $this->assertSame(
+            ['payload-one', 'payload-two'],
+            OrderMeta::get($order->get_id(), 'buckaroo_capture', false)
+        );
+    }
+
+    public function test_it_never_overwrites_a_value_already_on_the_order()
+    {
+        $order = $this->createOrder();
+        OrderMeta::update($order, '_wc_order_amount_captured', '99.99');
+        update_post_meta($order->get_id(), '_wc_order_amount_captured', '10.00');
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->assertSame('99.99', OrderMeta::get($order->get_id(), '_wc_order_amount_captured'));
+        $this->assertSame(['99.99'], OrderMeta::get($order->get_id(), '_wc_order_amount_captured', false));
+    }
+
+    /**
+     * The failure this migration exists to prevent: without the locks the new code
+     * reads an empty value on a legacy order, decides the refund has not happened and
+     * refunds a second time.
+     */
+    public function test_the_idempotency_locks_are_readable_by_the_new_code_after_migrating()
+    {
+        $order = $this->createOrder();
+        $transactionKey = 'LEGACY_TX_KEY';
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+        update_post_meta($order->get_id(), '_refundbuckaroo' . $transactionKey, 'ok');
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        // These two reads are exactly what RefundAction::initiateExternalServiceRefund
+        // does before deciding whether to create a refund.
+        $this->assertSame('ok', OrderMeta::get($order->get_id(), '_pushallowed'));
+        $this->assertNotEmpty(OrderMeta::get($order->get_id(), '_refundbuckaroo' . $transactionKey));
+    }
+
+    public function test_it_does_nothing_when_hpos_is_off()
+    {
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+
+        $this->disableHpos();
+
+        $this->assertFalse(MigrateOrderMetaToHpos::isNeeded());
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+        $this->enableHpos();
+        $this->assertSame('', OrderMeta::get($order->get_id(), '_pushallowed'));
+    }
+
+    /**
+     * WooCommerce's own sync cannot rescue these rows: it selects orders by a mismatch
+     * between date_updated_gmt and post_modified_gmt, and update_post_meta() never
+     * touches post_modified. So a store with sync on needs the copy too.
+     */
+    public function test_it_still_copies_when_posts_sync_is_on()
+    {
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+
+        update_option('woocommerce_custom_orders_table_data_sync_enabled', 'yes');
+
+        try {
+            $this->assertTrue(MigrateOrderMetaToHpos::isNeeded());
+
+            MigrateOrderMetaToHpos::runBatch($order->get_id() - 1);
+
+            $this->assertSame('ok', OrderMeta::get($order->get_id(), '_pushallowed'));
+        } finally {
+            update_option('woocommerce_custom_orders_table_data_sync_enabled', 'no');
+        }
+    }
+
+    /**
+     * The cursor only advances when the batch finishes, so a single unreadable order
+     * must not strand every order after it.
+     */
+    public function test_one_failing_order_does_not_stop_the_rest_of_the_batch()
+    {
+        $failing = $this->createOrder();
+        $healthy = $this->createOrder();
+        update_post_meta($failing->get_id(), '_pushallowed', 'ok');
+        update_post_meta($healthy->get_id(), '_pushallowed', 'ok');
+
+        // HPOS writes order meta with a raw $wpdb->insert, so no WP meta hook fires.
+        // Blow up on the first order meta insert instead, which belongs to the first
+        // order of the batch. Orders are copied in ascending id order.
+        $blownUp = false;
+        $blowUp = function ($query) use (&$blownUp) {
+            if (! $blownUp && stripos($query, 'INSERT') === 0 && stripos($query, 'wc_orders_meta') !== false) {
+                $blownUp = true;
+
+                throw new RuntimeException('Simulated failure while writing the order meta');
+            }
+
+            return $query;
+        };
+        add_filter('query', $blowUp);
+
+        try {
+            MigrateOrderMetaToHpos::runBatch($failing->get_id() - 1);
+        } finally {
+            remove_filter('query', $blowUp);
+        }
+
+        $this->assertTrue($blownUp, 'The simulated failure never fired');
+
+        $this->assertSame(
+            '',
+            OrderMeta::get($failing->get_id(), '_pushallowed'),
+            'The simulated failure has to actually stop this order being copied'
+        );
+        $this->assertSame(
+            'ok',
+            OrderMeta::get($healthy->get_id(), '_pushallowed'),
+            'The order after the failing one still has to be copied'
+        );
+    }
+
+    public function test_execute_queues_a_batch_instead_of_copying_synchronously()
+    {
+        if (! function_exists('as_has_scheduled_action')) {
+            $this->markTestSkipped('Action Scheduler is not available');
+        }
+
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+
+        (new MigrateOrderMetaToHpos())->execute();
+
+        $this->assertTrue(
+            as_has_scheduled_action(MigrateOrderMetaToHpos::BATCH_HOOK, [0], MigrateOrderMetaToHpos::ACTION_GROUP),
+            'The upgrade should queue the copy, not run it inline'
+        );
+        $this->assertSame(
+            '',
+            OrderMeta::get($order->get_id(), '_pushallowed'),
+            'Nothing should have been copied yet'
+        );
+    }
+
+    public function test_a_batch_covers_every_order_in_it_and_advances_the_cursor()
+    {
+        if (! function_exists('as_has_scheduled_action')) {
+            $this->markTestSkipped('Action Scheduler is not available');
+        }
+
+        $first = $this->createOrder();
+        $second = $this->createOrder();
+        update_post_meta($first->get_id(), '_pushallowed', 'ok');
+        update_post_meta($second->get_id(), '_pushallowed', 'ok');
+
+        MigrateOrderMetaToHpos::runBatch($first->get_id() - 1);
+
+        $this->assertSame('ok', OrderMeta::get($first->get_id(), '_pushallowed'));
+        $this->assertSame('ok', OrderMeta::get($second->get_id(), '_pushallowed'));
+
+        $this->assertTrue(
+            as_has_scheduled_action(
+                MigrateOrderMetaToHpos::BATCH_HOOK,
+                [$second->get_id()],
+                MigrateOrderMetaToHpos::ACTION_GROUP
+            ),
+            'The next batch should start after the last order of this one'
+        );
+    }
+
+    public function test_an_empty_batch_stops_scheduling()
+    {
+        if (! function_exists('as_has_scheduled_action')) {
+            $this->markTestSkipped('Action Scheduler is not available');
+        }
+
+        $order = $this->createOrder();
+        update_post_meta($order->get_id(), '_pushallowed', 'ok');
+
+        MigrateOrderMetaToHpos::runBatch($order->get_id());
+
+        $this->assertFalse(
+            as_has_scheduled_action(
+                MigrateOrderMetaToHpos::BATCH_HOOK,
+                [$order->get_id()],
+                MigrateOrderMetaToHpos::ACTION_GROUP
+            ),
+            'Nothing left to copy has to end the chain, not queue another batch'
+        );
+    }
+
+    /** Drive the chain over more orders than one batch holds. */
+    public function test_every_order_across_many_batches_is_migrated()
+    {
+        $count = (int) (MigrateOrderMetaToHpos::BATCH_SIZE * 2.5);
+        $ids = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $order = $this->createOrder();
+            $ids[] = $order->get_id();
+            update_post_meta($order->get_id(), '_pushallowed', 'ok');
+            update_post_meta($order->get_id(), '_refundbuckarooTX' . $i, 'ok');
+            add_post_meta($order->get_id(), '_wc_order_captures', ['id' => 'cap' . $i, 'amount' => '1.00']);
+            update_post_meta($order->get_id(), 'buckaroo_settlement', ['TX' . $i => 1.0]);
+        }
+
+        // Walk the chain the way Action Scheduler would: each batch returns the cursor
+        // for the next through the queued action's args.
+        $cursor = min($ids) - 1;
+        $batches = 0;
+
+        do {
+            as_unschedule_all_actions(MigrateOrderMetaToHpos::BATCH_HOOK);
+            MigrateOrderMetaToHpos::runBatch($cursor);
+            $batches++;
+
+            $next = null;
+            foreach (as_get_scheduled_actions([
+                'hook' => MigrateOrderMetaToHpos::BATCH_HOOK,
+                'group' => MigrateOrderMetaToHpos::ACTION_GROUP,
+                'status' => ActionScheduler_Store::STATUS_PENDING,
+                'per_page' => 1,
+            ]) as $action) {
+                $args = $action->get_args();
+                $next = (int) reset($args);
+            }
+
+            $progressed = $next !== null && $next > $cursor;
+            $cursor = $next ?? $cursor;
+        } while ($progressed && $batches < 20);
+
+        $this->assertGreaterThan(2, $batches, 'The data should have needed more than one batch');
+
+        $missed = [];
+        foreach ($ids as $i => $id) {
+            if (OrderMeta::get($id, '_pushallowed') !== 'ok'
+                || OrderMeta::get($id, '_refundbuckarooTX' . $i) !== 'ok'
+                || OrderMeta::get($id, 'buckaroo_settlement') !== ['TX' . $i => 1.0]
+                || array_column(OrderMeta::get($id, '_wc_order_captures', false), 'id') !== ['cap' . $i]) {
+                $missed[] = $id;
+            }
+        }
+
+        $this->assertSame([], $missed, 'Every order in every batch has to be migrated');
+    }
+
+    public function test_the_batch_hook_is_wired_up_for_action_scheduler()
+    {
+        MigrateOrderMetaToHpos::registerBatchHandler();
+
+        $this->assertNotFalse(
+            has_action(MigrateOrderMetaToHpos::BATCH_HOOK, [MigrateOrderMetaToHpos::class, 'runBatch'])
+        );
+    }
+}

--- a/tests/Test_OrderActions.php
+++ b/tests/Test_OrderActions.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use Buckaroo\Woocommerce\Gateways\AbstractPaymentGateway;
+use Buckaroo\Woocommerce\Hooks\OrderActions;
+use Buckaroo\Woocommerce\Order\OrderMeta;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Under HPOS the admin hands these hooks an order object rather than a post.
+ */
+class Test_OrderActions extends TestCase
+{
+    use HposStorage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists('WC_Order')) {
+            $this->markTestSkipped('WooCommerce is not available');
+        }
+
+        $this->enableHpos();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteCreatedOrders();
+        $this->disableHpos();
+        parent::tearDown();
+    }
+
+    public function test_test_mode_notice_shows_for_an_order_object_on_an_hpos_store()
+    {
+        $order = $this->createOrder();
+        OrderMeta::update($order, '_buckaroo_order_in_test_mode', true);
+
+        $output = $this->renderTestModeNotice(wc_get_order($order->get_id()));
+
+        $this->assertStringContainsString('test mode', $output);
+    }
+
+    public function test_test_mode_notice_is_silent_when_the_order_was_not_in_test_mode()
+    {
+        $order = $this->createOrder();
+
+        $output = $this->renderTestModeNotice(wc_get_order($order->get_id()));
+
+        $this->assertSame('', $output);
+    }
+
+    public function test_test_mode_notice_is_silent_when_the_flag_is_switched_off()
+    {
+        $order = $this->createOrder();
+        OrderMeta::update($order, '_buckaroo_order_in_test_mode', false);
+
+        $output = $this->renderTestModeNotice(wc_get_order($order->get_id()));
+
+        $this->assertSame('', $output);
+    }
+
+    public function test_test_mode_notice_ignores_a_post_that_is_not_an_order()
+    {
+        $postId = wp_insert_post([
+            'post_title' => 'Not an order',
+            'post_type' => 'post',
+            'post_status' => 'publish',
+        ]);
+
+        $output = $this->renderTestModeNotice(get_post($postId));
+
+        $this->assertSame('', $output);
+
+        wp_delete_post($postId, true);
+    }
+
+    /** The action buttons resolve their gateway from _wc_order_selected_payment_method. */
+    public function test_order_actions_resolve_their_gateway_from_order_meta()
+    {
+        $order = $this->createOrder();
+        OrderMeta::update($order, '_wc_order_selected_payment_method', 'KlarnaPay');
+
+        $gateway = $this->resolveCapturableGateway($order->get_id());
+
+        $this->assertInstanceOf(AbstractPaymentGateway::class, $gateway);
+        $this->assertSame('buckaroo_klarnapay', $gateway->id);
+    }
+
+    public function test_order_actions_fall_back_to_the_woocommerce_payment_method()
+    {
+        $order = $this->createOrder();
+        $order->set_payment_method('buckaroo_ideal');
+        $order->save();
+
+        $gateway = $this->resolveCapturableGateway($order->get_id());
+
+        $this->assertInstanceOf(AbstractPaymentGateway::class, $gateway);
+        $this->assertSame('buckaroo_ideal', $gateway->id);
+    }
+
+    public function test_order_actions_resolve_nothing_for_a_non_buckaroo_order()
+    {
+        $order = $this->createOrder();
+        $order->set_payment_method('cod');
+        $order->save();
+
+        $this->assertNull($this->resolveCapturableGateway($order->get_id()));
+    }
+
+    /**
+     * @param  WC_Order|WP_Post  $postOrOrder
+     */
+    private function renderTestModeNotice($postOrOrder): string
+    {
+        ob_start();
+        (new OrderActions())->handleOrderInTestMode($postOrOrder);
+
+        return (string) ob_get_clean();
+    }
+
+    private function resolveCapturableGateway(int $orderId): ?AbstractPaymentGateway
+    {
+        $method = new \ReflectionMethod(OrderActions::class, 'resolveCapturableGateway');
+        $method->setAccessible(true);
+
+        return $method->invoke(new OrderActions(), $orderId);
+    }
+}

--- a/tests/Test_OrderMeta.php
+++ b/tests/Test_OrderMeta.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+use Buckaroo\Woocommerce\Order\OrderMeta;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs with HPOS on and posts sync off, where post meta and order meta diverge.
+ */
+class Test_OrderMeta extends TestCase
+{
+    use HposStorage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists('WC_Order')) {
+            $this->markTestSkipped('WooCommerce is not available');
+        }
+
+        $this->enableHpos();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteCreatedOrders();
+        $this->disableHpos();
+        parent::tearDown();
+    }
+
+    public function test_writes_land_in_order_meta_not_post_meta()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::update($order->get_id(), '_pushallowed', 'ok');
+
+        $this->assertSame('ok', wc_get_order($order->get_id())->get_meta('_pushallowed', true));
+        $this->assertSame('', get_post_meta($order->get_id(), '_pushallowed', true));
+    }
+
+    public function test_writes_land_in_the_wc_orders_meta_table()
+    {
+        global $wpdb;
+
+        $order = $this->createOrder();
+
+        OrderMeta::update($order, '_buckaroo_klarnakp_reservation_number', '556677');
+
+        $this->assertSame(
+            '556677',
+            $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT meta_value FROM {$wpdb->prefix}wc_orders_meta
+                     WHERE order_id = %d AND meta_key = %s",
+                    $order->get_id(),
+                    '_buckaroo_klarnakp_reservation_number'
+                )
+            )
+        );
+        $this->assertNull(
+            $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT meta_value FROM {$wpdb->postmeta}
+                     WHERE post_id = %d AND meta_key = %s",
+                    $order->get_id(),
+                    '_buckaroo_klarnakp_reservation_number'
+                )
+            ),
+            'Nothing should be left behind on the placeholder post row'
+        );
+    }
+
+    public function test_get_single_returns_empty_string_for_missing_key()
+    {
+        $order = $this->createOrder();
+
+        $this->assertSame('', OrderMeta::get($order->get_id(), '_buckaroo_missing_key'));
+        $this->assertSame(
+            get_post_meta($order->get_id(), '_buckaroo_missing_key', true),
+            OrderMeta::get($order->get_id(), '_buckaroo_missing_key')
+        );
+    }
+
+    public function test_get_non_single_returns_empty_array_for_missing_key()
+    {
+        $order = $this->createOrder();
+
+        $this->assertSame([], OrderMeta::get($order->get_id(), '_buckaroo_missing_key', false));
+    }
+
+    public function test_get_non_single_returns_plain_values_not_meta_objects()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::add($order, '_wc_order_captures', ['id' => 'a', 'amount' => '1.00']);
+        OrderMeta::add($order, '_wc_order_captures', ['id' => 'b', 'amount' => '2.00']);
+
+        $captures = OrderMeta::get($order->get_id(), '_wc_order_captures', false);
+
+        $this->assertSame(
+            [
+                ['id' => 'a', 'amount' => '1.00'],
+                ['id' => 'b', 'amount' => '2.00'],
+            ],
+            $captures
+        );
+    }
+
+    /** AbstractRefundProcessor takes end($captures) to choose what it refunds against. */
+    public function test_non_single_returns_values_in_meta_id_order_not_storage_order()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::add($order, '_wc_order_captures', ['id' => 'first', 'transaction_id' => 'TX_FIRST']);
+        OrderMeta::add($order, '_wc_order_captures', ['id' => 'second', 'transaction_id' => 'TX_SECOND']);
+
+        $fresh = wc_get_order($order->get_id());
+
+        // The HPOS meta query has no ORDER BY, so the rows can arrive in any order.
+        // MySQL happens to return primary-key order here, which would make this test
+        // vacuous, so feed the seam genuinely reversed rows.
+        $this->reverseLoadedMetaData($fresh);
+
+        $captures = OrderMeta::get($fresh, '_wc_order_captures', false);
+
+        $this->assertCount(2, $captures, 'Both rows should be read back');
+        $this->assertSame(
+            ['first', 'second'],
+            array_column($captures, 'id'),
+            'Values have to come back in meta_id order, whatever order storage returned'
+        );
+
+        $lastCapture = end($captures);
+        $this->assertSame(
+            'TX_SECOND',
+            $lastCapture['transaction_id'],
+            'end() has to give the newest capture, which is what a refund is sent against'
+        );
+    }
+
+    /**
+     * Reverse the order object's already-loaded meta rows, simulating storage handing
+     * them back in a different order than meta_id ascending.
+     */
+    private function reverseLoadedMetaData(WC_Order $order): void
+    {
+        $property = new \ReflectionProperty(WC_Data::class, 'meta_data');
+        $property->setAccessible(true);
+        $property->setValue($order, array_reverse($property->getValue($order)));
+    }
+
+    public function test_update_replaces_the_existing_value()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::update($order, '_wc_order_amount_captured', '10.00');
+        OrderMeta::update($order, '_wc_order_amount_captured', '25.00');
+
+        $this->assertSame('25.00', OrderMeta::get($order->get_id(), '_wc_order_amount_captured'));
+        $this->assertSame(['25.00'], OrderMeta::get($order->get_id(), '_wc_order_amount_captured', false));
+    }
+
+    public function test_add_unique_writes_nothing_and_returns_false_when_key_exists()
+    {
+        $order = $this->createOrder();
+
+        $this->assertTrue(OrderMeta::add($order, '_pushallowed', 'ok', true));
+        $this->assertFalse(OrderMeta::add($order, '_pushallowed', 'second', true));
+
+        $this->assertSame(['ok'], OrderMeta::get($order->get_id(), '_pushallowed', false));
+    }
+
+    public function test_add_without_unique_appends_a_second_value()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::add($order, 'buckaroo_capture', 'first');
+        OrderMeta::add($order, 'buckaroo_capture', 'second');
+
+        $this->assertSame(['first', 'second'], OrderMeta::get($order->get_id(), 'buckaroo_capture', false));
+    }
+
+    public function test_delete_removes_every_value_for_the_key()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::add($order, 'buckaroo_capture', 'first');
+        OrderMeta::add($order, 'buckaroo_capture', 'second');
+
+        $this->assertTrue(OrderMeta::delete($order, 'buckaroo_capture'));
+        $this->assertSame([], OrderMeta::get($order->get_id(), 'buckaroo_capture', false));
+    }
+
+    public function test_several_writes_on_one_order_object_persist_without_an_explicit_save()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::update($order, '_wc_order_is_captured', true);
+        OrderMeta::update($order, '_wc_order_amount_captured', '12.34');
+        OrderMeta::add($order, '_capturebuckarooABC123', 'ok', true);
+
+        $fresh = wc_get_order($order->get_id());
+
+        $this->assertSame('1', $fresh->get_meta('_wc_order_is_captured', true));
+        $this->assertSame('12.34', $fresh->get_meta('_wc_order_amount_captured', true));
+        $this->assertSame('ok', $fresh->get_meta('_capturebuckarooABC123', true));
+    }
+
+    public function test_writes_through_an_order_object_are_visible_by_id()
+    {
+        $order = $this->createOrder();
+
+        OrderMeta::update($order, '_buckaroo_klarnakp_reservation_number', '998877');
+
+        $this->assertSame(
+            '998877',
+            OrderMeta::get($order->get_id(), '_buckaroo_klarnakp_reservation_number')
+        );
+    }
+
+    public function test_non_order_id_falls_back_to_post_meta()
+    {
+        $postId = wp_insert_post([
+            'post_title' => 'Not an order',
+            'post_type' => 'post',
+            'post_status' => 'publish',
+        ]);
+
+        $this->assertTrue(OrderMeta::update($postId, '_buckaroo_probe', 'x'));
+        $this->assertSame('x', OrderMeta::get($postId, '_buckaroo_probe'));
+        $this->assertSame('x', get_post_meta($postId, '_buckaroo_probe', true));
+
+        $this->assertSame(['x'], OrderMeta::get($postId, '_buckaroo_probe', false));
+
+        $this->assertFalse(OrderMeta::add($postId, '_buckaroo_probe', 'y', true));
+        $this->assertSame(['x'], OrderMeta::get($postId, '_buckaroo_probe', false));
+
+        $this->assertTrue(OrderMeta::delete($postId, '_buckaroo_probe'));
+        $this->assertSame('', OrderMeta::get($postId, '_buckaroo_probe'));
+
+        wp_delete_post($postId, true);
+    }
+
+    public function test_unknown_id_does_not_fatal()
+    {
+        $unknownId = 999999999;
+
+        $this->assertSame('', OrderMeta::get($unknownId, '_buckaroo_probe'));
+        $this->assertSame([], OrderMeta::get($unknownId, '_buckaroo_probe', false));
+    }
+}

--- a/tests/Test_PushProcessorReplay.php
+++ b/tests/Test_PushProcessorReplay.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use Buckaroo\Woocommerce\Order\OrderMeta;
+use Buckaroo\Woocommerce\PaymentProcessors\PushProcessor;
+use Buckaroo\Woocommerce\ResponseParser\ResponseParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A push can arrive twice for the same transaction; settlement meta and the
+ * _pushallowed lock stop the second one counting as a new payment.
+ */
+class Test_PushProcessorReplay extends TestCase
+{
+    use HposStorage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists('WC_Order')) {
+            $this->markTestSkipped('WooCommerce is not available');
+        }
+
+        $this->enableHpos();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteCreatedOrders();
+        $this->disableHpos();
+        parent::tearDown();
+    }
+
+    public function test_settlement_meta_round_trips_through_order_meta()
+    {
+        $order = $this->createOrder();
+
+        $this->updateSettlementMeta($order, 'TX_ONE', 20.00);
+
+        $this->assertSame(
+            ['TX_ONE' => 20.00],
+            OrderMeta::get($order->get_id(), 'buckaroo_settlement'),
+            'Settlement meta should be readable back through the order meta API'
+        );
+        $this->assertSame(
+            '',
+            get_post_meta($order->get_id(), 'buckaroo_settlement', true),
+            'Settlement meta should no longer be written to post meta'
+        );
+    }
+
+    public function test_a_replayed_push_is_not_counted_as_a_new_payment()
+    {
+        $order = $this->createOrder();
+
+        $first = $this->calculateSettlementState($order, 'TX_ONE', 20.00);
+        $this->assertTrue($first['isNewPayment']);
+        $this->assertSame(20.00, $first['totalPaid']);
+
+        $this->updateSettlementMeta($order, 'TX_ONE', 20.00);
+
+        $replay = $this->calculateSettlementState($order, 'TX_ONE', 20.00);
+        $this->assertFalse($replay['isNewPayment'], 'A replayed transaction key is not a new payment');
+        $this->assertSame(20.00, $replay['totalPaid'], 'A replayed push must not inflate the total paid');
+    }
+
+    public function test_a_second_partial_payment_is_counted_once_and_added_to_the_total()
+    {
+        $order = $this->createOrder();
+
+        $this->updateSettlementMeta($order, 'TX_ONE', 20.00);
+
+        $second = $this->calculateSettlementState($order, 'TX_TWO', 30.00);
+        $this->assertTrue($second['isNewPayment']);
+        $this->assertSame(50.00, $second['totalPaid']);
+
+        $this->updateSettlementMeta($order, 'TX_TWO', 30.00);
+
+        $replay = $this->calculateSettlementState($order, 'TX_TWO', 30.00);
+        $this->assertFalse($replay['isNewPayment']);
+        $this->assertSame(50.00, $replay['totalPaid']);
+    }
+
+    /** Written with $unique = true, so a replay must leave a single value. */
+    public function test_a_replayed_push_writes_the_pushallowed_lock_only_once()
+    {
+        $order = $this->createOrder();
+
+        $this->assertTrue(OrderMeta::add($order, '_pushallowed', 'ok', true));
+        $this->assertFalse(OrderMeta::add($order, '_pushallowed', 'ok', true));
+
+        $this->assertSame(['ok'], OrderMeta::get($order->get_id(), '_pushallowed', false));
+    }
+
+    private function calculateSettlementState(WC_Order $order, string $transactionKey, float $paidAmount): array
+    {
+        return $this->callProcessor('calculateSettlementState', $order, $transactionKey, $paidAmount);
+    }
+
+    private function updateSettlementMeta(WC_Order $order, string $transactionKey, float $paidAmount): void
+    {
+        $this->callProcessor('updateSettlementMeta', $order, $transactionKey, $paidAmount);
+    }
+
+    /**
+     * @return mixed
+     */
+    private function callProcessor(string $method, WC_Order $order, string $transactionKey, float $paidAmount)
+    {
+        $processor = new PushProcessor();
+
+        $reflectionMethod = new \ReflectionMethod(PushProcessor::class, $method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invoke(
+            $processor,
+            $order,
+            $this->createResponseParser($transactionKey),
+            $paidAmount
+        );
+    }
+
+    private function createResponseParser(string $transactionKey): ResponseParser
+    {
+        $responseParser = $this->getMockBuilder(ResponseParser::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getTransactionKey', 'getRelatedTransactionPartialPayment'])
+            ->getMockForAbstractClass();
+
+        $responseParser->method('getTransactionKey')->willReturn($transactionKey);
+        $responseParser->method('getRelatedTransactionPartialPayment')->willReturn(null);
+
+        return $responseParser;
+    }
+}

--- a/tests/Test_RefundAction.php
+++ b/tests/Test_RefundAction.php
@@ -2,12 +2,22 @@
 
 declare(strict_types=1);
 
+use Buckaroo\Woocommerce\Order\OrderMeta;
 use Buckaroo\Woocommerce\PaymentProcessors\Actions\RefundAction;
 use BuckarooDeps\Buckaroo\Transaction\Response\TransactionResponse;
 use PHPUnit\Framework\TestCase;
 
 class Test_RefundAction extends TestCase
 {
+    use HposStorage;
+
+    protected function tearDown(): void
+    {
+        $this->deleteCreatedOrders();
+        $this->disableHpos();
+        parent::tearDown();
+    }
+
     /**
      * @dataProvider pendingStatusCodeProvider
      */
@@ -43,15 +53,58 @@ class Test_RefundAction extends TestCase
 
     public function test_finalize_sets_refund_meta_for_pending_status()
     {
-        $orderId = $this->createTestOrderId();
-        $refundAction = $this->createRefundAction($orderId);
+        $this->enableHpos();
+
+        $order = $this->createOrder();
+        $refundAction = $this->createRefundAction($order);
         $transactionKey = 'PENDING_TX_KEY_793';
         $response = $this->createMockResponse(793, $transactionKey);
 
         $refundAction->finalize($response);
 
-        $meta = get_post_meta($orderId, '_refundbuckaroo' . $transactionKey, true);
-        $this->assertEquals('ok', $meta, 'Pending refund should set _refundbuckaroo meta to prevent duplicate on push');
+        $this->assertEquals(
+            'ok',
+            OrderMeta::get($order->get_id(), '_refundbuckaroo' . $transactionKey),
+            'Pending refund should set _refundbuckaroo meta to prevent duplicate on push'
+        );
+    }
+
+    /**
+     * _refundbuckaroo<key> is the idempotency lock that stops a replayed Buckaroo
+     * push from refunding twice. It is written with $unique = true, so a replay has
+     * to leave exactly one value behind.
+     */
+    public function test_finalize_replayed_twice_writes_the_refund_lock_only_once()
+    {
+        $this->enableHpos();
+
+        $order = $this->createOrder();
+        $refundAction = $this->createRefundAction($order);
+        $transactionKey = 'REPLAYED_TX_KEY';
+        $response = $this->createMockResponse(190, $transactionKey);
+
+        $refundAction->finalize($response);
+        $refundAction->finalize($response);
+
+        $this->assertSame(
+            ['ok'],
+            OrderMeta::get($order->get_id(), '_refundbuckaroo' . $transactionKey, false),
+            'A replayed refund must not add a second lock value'
+        );
+    }
+
+    public function test_finalize_locks_each_transaction_key_separately()
+    {
+        $this->enableHpos();
+
+        $order = $this->createOrder();
+        $refundAction = $this->createRefundAction($order);
+
+        $refundAction->finalize($this->createMockResponse(190, 'TX_ONE'));
+        $refundAction->finalize($this->createMockResponse(190, 'TX_TWO'));
+
+        $this->assertSame(['ok'], OrderMeta::get($order->get_id(), '_refundbuckarooTX_ONE', false));
+        $this->assertSame(['ok'], OrderMeta::get($order->get_id(), '_refundbuckarooTX_TWO', false));
     }
 
     public function test_finalize_adds_pending_order_note()
@@ -75,14 +128,20 @@ class Test_RefundAction extends TestCase
         ];
     }
 
-    private function createRefundAction(?int $orderId = null): RefundAction
+    /**
+     * @param  WC_Order|null  $order  A real order when the test asserts on order meta,
+     *                                otherwise a mock is enough
+     */
+    private function createRefundAction($order = null): RefundAction
     {
         $reflection = new \ReflectionClass(RefundAction::class);
         $refundAction = $reflection->newInstanceWithoutConstructor();
 
-        $order = $this->createMock(\WC_Order::class);
-        $order->method('get_id')->willReturn($orderId ?? 99999);
-        $order->method('get_transaction_id')->willReturn('ORIG_TX_KEY');
+        if ($order === null) {
+            $order = $this->createMock(\WC_Order::class);
+            $order->method('get_id')->willReturn(99999);
+            $order->method('get_transaction_id')->willReturn('ORIG_TX_KEY');
+        }
 
         $orderProp = $reflection->getProperty('order');
         $orderProp->setAccessible(true);
@@ -114,13 +173,5 @@ class Test_RefundAction extends TestCase
         $response->method('getSomeError')->willReturn('Test error');
 
         return $response;
-    }
-
-    private function createTestOrderId(): int
-    {
-        return wp_insert_post([
-            'post_type' => 'shop_order',
-            'post_status' => 'wc-processing',
-        ]);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,3 +26,6 @@ tests_add_filter('muplugins_loaded', '_manually_load_plugin');
 
 // Start up the WP testing environment.
 require $_tests_dir.'/includes/bootstrap.php';
+
+// Shared test helpers, loaded after WooCommerce so they can reference its classes.
+require_once __DIR__.'/Support/HposStorage.php';


### PR DESCRIPTION
- All order meta now goes through one accessor that uses the WooCommerce order meta API, so it lands in `wp_wc_orders_meta` instead of the `shop_order_placehold` post row under HPOS. Post-meta fallback kept for non-HPOS stores.
- New 4.9.1 migration copies existing Buckaroo order meta across in Action Scheduler batches — copies rather than moves, never overwrites, safe to rerun.
- Orders are copied on demand before push and capture read their idempotency locks, so a replayed push cannot capture or refund twice while the migration is still running.
- Fixes `Helper::resetOrder()` (never ran on HPOS — it read the status via `get_post_status()`), and declares WooCommerce 11.0 + `custom_order_tables` compatibility. Version bumped to 4.9.1, which the migration is gated on.
- Verified: 502 tests green, phpcs clean, plus real Buckaroo payments on a WC 11.0 HPOS store (iDEAL + refund, Riverty authorize→capture→refund) confirming meta lands only in `wp_wc_orders_meta`.